### PR TITLE
Speed up _cat_describe

### DIFF
--- a/tableone.py
+++ b/tableone.py
@@ -157,6 +157,8 @@ class TableOne(object):
                 left_on='level',right_index=True, how='left')
             df['freq'].fillna(0,inplace=True)
             df['percent'] = (df['freq'] / df['n']) * 100
+            # set level as index to df
+            df.set_index('level', inplace=True)
             cats[v] = df
 
         return cats
@@ -303,7 +305,7 @@ class TableOne(object):
 
             # add isnull values column
             if self.isnull:
-                row.append(data[v].isnull().sum())            
+                row.append(data[v].isnull().sum())
 
             # add pval column
             if self.pval:
@@ -317,9 +319,11 @@ class TableOne(object):
                 row = ["{}".format(level)]
                 # for each strata
                 for strata in self.strata:
-                    vals = self._cat_describe[strata][v][self._cat_describe[strata][v]['level']==level]
-                    freq = vals['freq'].values[0]
-                    percent = vals['percent'].values[0]
+                    # get data frame with info about each individual level
+                    vals = self._cat_describe[strata][v]
+                    freq = vals.loc[level, 'freq']
+                    percent = vals.loc[level, 'percent']
+
                     row.append("{:0.0f} ({:0.2f})".format(freq,percent))
                 # stack rows to create the table
                 table.append(row)
@@ -337,12 +341,12 @@ class TableOne(object):
                 n.append('{:0.0f}'.format(count))
             if self.isnull:
                 isnull = data[self.groupby].isnull().sum()
-                n.append('{:0.0f}'.format(isnull)) 
+                n.append('{:0.0f}'.format(isnull))
         else:
             count = len(data.index)
             n.append("{:0.0f}".format(count))
             if self.isnull:
-                n.append('') 
+                n.append('')
 
         if self.pval:
             n.append('')

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -21,6 +21,7 @@ class TestTableOne(object):
         self.create_sample_dataset(n = 10000)
         self.create_small_dataset()
         self.create_another_dataset(n = 20)
+        self.create_categorical_dataset()
 
     def create_pbc_dataset(self):
         """
@@ -86,11 +87,19 @@ class TestTableOne(object):
         self.data_groups['age'] = range(n)
         self.data_groups['weight'] = [x+100 for x in range(n)]
 
-    def create_categorical_dataset(self, n):
+    def create_categorical_dataset(self, n_cat=100, n_obs_per_cat=1000, n_col=10):
         """
         create a dataframe with many categories of many levels
         """
-        self.data_categorical = pd.DataFrame(np.mod(np.arange(100000),100).reshape(10000,10))
+        # dataframe with many categories of many levels
+        # generate integers to represent data
+        data = np.arange(n_cat*n_obs_per_cat*n_col)
+        # use modulus to create categories - unique for each column
+        data = np.mod(data,n_cat*n_col)
+        # reshape intro a matrix
+        data = data.reshape(n_cat*n_obs_per_cat, n_col)
+
+        self.data_categorical = pd.DataFrame(data)
 
     def teardown(self):
         """
@@ -209,7 +218,7 @@ class TestTableOne(object):
         Ensure that the package runs Fisher exact if cell counts are <=5 and it's a 2x2
         """
         categorical=['group1','group3']
-        table = TableOne(self.data_categorical, categorical=np.arange(10))
+        table = TableOne(self.data_categorical, categorical=list(np.arange(10)))
 
         # each column
         for i in np.arange(10):

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -137,10 +137,11 @@ class TestTableOne(object):
         categorical=['likesmarmalade']
         table = TableOne(self.data_sample, categorical=categorical)
 
-        notlikefreq = table._cat_describe['overall']['likesmarmalade'][table._cat_describe['overall']['likesmarmalade']['level']==0]['freq'].values[0]
-        notlikepercent = table._cat_describe['overall']['likesmarmalade'][table._cat_describe['overall']['likesmarmalade']['level']==0]['percent'].values[0]
-        likefreq = table._cat_describe['overall']['likesmarmalade'][table._cat_describe['overall']['likesmarmalade']['level']==1]['freq'].values[0]
-        likepercent = table._cat_describe['overall']['likesmarmalade'][table._cat_describe['overall']['likesmarmalade']['level']==1]['percent'].values[0]
+        lm = table._cat_describe['overall']['likesmarmalade']
+        notlikefreq = lm.loc[0,'freq']
+        notlikepercent = lm.loc[0,'percent']
+        likefreq = lm.loc[1,'freq']
+        likepercent = lm.loc[1,'percent']
 
         assert notlikefreq + likefreq == 10000
         assert abs(100 - notlikepercent - likepercent) <= 0.02
@@ -155,8 +156,9 @@ class TestTableOne(object):
         categorical=['likeshoney']
         table = TableOne(self.data_sample, categorical=categorical)
 
-        likefreq = table._cat_describe['overall']['likeshoney'][table._cat_describe['overall']['likeshoney']['level']==1.0]['freq'].values[0]
-        likepercent = table._cat_describe['overall']['likeshoney'][table._cat_describe['overall']['likeshoney']['level']==1.0]['percent'].values[0]
+        lh = table._cat_describe['overall']['likeshoney']
+        likefreq = lh.loc[1.0,'freq']
+        likepercent = lh.loc[1.0,'percent']
 
         assert likefreq == 5993
         assert abs(100-likepercent) <= 0.01


### PR DESCRIPTION
This speeds up the _cat_describe function ~10-40 times or so by using the levels as an index in the dataframe