### PR TITLE
Continuous describe can now handle mixed datatypes

### DIFF
--- a/tableone.py
+++ b/tableone.py
@@ -581,14 +581,11 @@ class TableOne(object):
         table : pandas DataFrame
             A table summarising the categorical variables.
         """
-        table = self.cat_describe['isnull'].copy()
-        # if there are _groupby levels, `table` has multiple columns
-        # each column is named according to the group
-        # to ensure one column is named isnull, we rename it here
-        table.rename(columns={table.columns[0]: 'isnull'}, inplace=True)
-
-        for g in self._groupbylvls:
-            table[g] = self.cat_describe['t1_summary'][g]
+        table = self.cat_describe['t1_summary'].copy()
+        # add the total count of null values across all levels
+        isnull = data[self._categorical].isnull().sum().to_frame(name='isnull')
+        isnull.index.rename('variable', inplace=True)
+        table = table.join(isnull)
 
         # add pval column
         if self._pval and self._pval_adjust:

--- a/tableone.py
+++ b/tableone.py
@@ -499,7 +499,7 @@ class TableOne(object):
         # no test by default
         pval=np.nan
         ptest='Not tested'
-
+        
         # do not test if the variable has no observations in a level
         if min_observed == 0:
             warnings.warn('No p-value was computed for {} due to the low number of observations.'.format(v))

--- a/tableone.py
+++ b/tableone.py
@@ -93,8 +93,9 @@ class TableOne(object):
             raise InputError('Columns not found in dataset: {}'.format(notfound))
 
         # check for duplicate columns
-        if data[columns].columns.get_duplicates():
-            raise InputError('Input contains duplicate columns: {}'.format())
+        dups = data[columns].columns.get_duplicates()
+        if dups:
+            raise InputError('Input contains duplicate columns: {}'.format(dups))
 
         # if categorical not specified, try to identify categorical
         if not categorical and type(categorical) != list:

--- a/tableone.py
+++ b/tableone.py
@@ -511,7 +511,7 @@ class TableOne(object):
         # no test by default
         pval=np.nan
         ptest='Not tested'
-        
+
         # do not test if the variable has no observations in a level
         if min_observed == 0:
             warnings.warn('No p-value was computed for {} due to the low number of observations.'.format(v))
@@ -557,8 +557,7 @@ class TableOne(object):
         table.columns = table.columns.droplevel(level=0)
 
         # add a column of null counts as 1-count() from previous function
-        nulltable = (data.shape[0] - self.cont_describe[['count']].sum(axis=1))
-        nulltable = nulltable.to_frame(name='isnull')
+        nulltable = data[self._continuous].isnull().sum().to_frame(name='isnull')
         table = table.join(nulltable)
 
         # add an empty level column, for joining with cat table

--- a/tableone.py
+++ b/tableone.py
@@ -324,16 +324,30 @@ class TableOne(object):
             self._q25,self._q75,min,max,self._t1_summary,self._diptest,
             self._outliers, self._far_outliers]
 
+        # coerce continuous data to numeric
+        cont_data = data[self._continuous].apply(pd.to_numeric, errors='coerce')
+        # check all data in each continuous column is numeric
+        bad_cols = cont_data.count() != data[self._continuous].count()
+        bad_cols = cont_data.columns[bad_cols]
+        if len(bad_cols)>0:
+            raise InputError("""The following continuous column(s) have non-numeric values: {}.
+            Either specify the column(s) as categorical or remove the non-numeric values.""".format(bad_cols.values))
+
+        # check for coerced column containing all NaN to warn user
+        for column in cont_data.columns[cont_data.count() == 0]:
+            self._non_continuous_warning(column)
+
         if self._groupby:
-            cont_data = data[self._continuous + [self._groupby]]
-            cont_data = cont_data.apply(pd.to_numeric, errors='ignore')
+            # add the groupby column back
+            cont_data = cont_data.merge(data[[self._groupby]], left_index=True, right_index=True)
+
+            # group and aggregate data
             df_cont = pd.pivot_table(cont_data,
                 columns=[self._groupby],
                 aggfunc=aggfuncs)
         else:
             # if no groupby, just add single group column
-            df_cont = data[self._continuous].apply(pd.to_numeric,
-                errors='ignore').apply(aggfuncs).T
+            df_cont = cont_data.apply(aggfuncs).T
             df_cont.columns.name = 'overall'
             df_cont.columns = pd.MultiIndex.from_product([df_cont.columns,
                 ['overall']])
@@ -421,7 +435,6 @@ class TableOne(object):
 
         # list values for each variable, grouped by groupby levels
         for v in df.index:
-
             is_continuous = df.loc[v]['continuous']
             is_categorical = ~df.loc[v]['continuous']
             is_normal = ~df.loc[v]['nonnormal']
@@ -431,7 +444,10 @@ class TableOne(object):
                 catlevels = None
                 grouped_data = []
                 for s in self._groupbylvls:
-                    lvl_data = data[data[self._groupby]==s].dropna(subset=[v])[v]
+                    lvl_data = data.loc[data[self._groupby]==s, v]
+                    # coerce to numeric and drop non-numeric data
+                    lvl_data = lvl_data.apply(pd.to_numeric, errors='coerce').dropna()
+                    # append to overall group data
                     grouped_data.append(lvl_data.values)
                 min_observed = len(min(grouped_data,key=len))
             # if categorical, create contingency table
@@ -528,8 +544,9 @@ class TableOne(object):
         table = self.cont_describe[['t1_summary']].copy()
         table.columns = table.columns.droplevel(level=0)
 
-        # add a column of null counts
-        nulltable = pd.DataFrame(data[self._continuous].isnull().sum().rename('isnull'))
+        # add a column of null counts as 1-count() from previous function
+        nulltable = (data.shape[0] - self.cont_describe[['count']].sum(axis=1))
+        nulltable = nulltable.to_frame(name='isnull')
         table = table.join(nulltable)
 
         # add an empty level column, for joining with cat table
@@ -688,3 +705,7 @@ class TableOne(object):
             table = table.reindex(cols, axis=1)
 
         return table
+
+    # warnings
+    def _non_continuous_warning(self, c):
+        warnings.warn('"{}" has all non-numeric values. Consider including it in the list of categorical variables.'.format(c), RuntimeWarning, stacklevel=2)

--- a/tableone.py
+++ b/tableone.py
@@ -534,7 +534,7 @@ class TableOne(object):
             # if this is a 2x2, switch to fisher exact
             if expected.min() < 5:
                 if grouped_data.shape == (2,2):
-                    ptest = 'Fisher''s exact'
+                    ptest = "Fisher's exact"
                     oddsratio, pval = stats.fisher_exact(grouped_data)
                 else:
                     ptest = 'Chi-squared (warning: expected count < 5)'

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -597,3 +597,36 @@ class TestTableOne(object):
         for i, c in enumerate(np.sort(columns)):
             # i+1 because we skip the first row, 'n'
             assert tableone_rows[i+1] == c
+
+
+    @with_setup(setup, teardown)
+    def test_check_null_counts_are_correct(self):
+
+        columns = ['age','bili','albumin','ast','platelet','protime',
+                   'ascites','hepato','spiders', 'edema','sex','trt']
+        categorical = ['ascites','hepato','edema','sex','spiders','trt']
+        groupby = 'trt'
+
+        # test when not grouping
+        table = TableOne(self.data_pbc, columns, categorical)
+
+        # get isnull column only
+        isnull = table.tableone.iloc[:,0]
+        for i, v in enumerate(isnull):
+            # skip empty rows by checking value is not a string
+            if 'float' in str(type(v)):
+                # check each null count is correct
+                col = isnull.index[i][0]
+                assert self.data_pbc[col].isnull().sum() == v
+
+        # test when grouping by a variable
+        grouped_table = TableOne(self.data_pbc, columns, categorical, groupby)
+
+        # get isnull column only
+        isnull = grouped_table.tableone.iloc[:,0]
+        for i, v in enumerate(isnull):
+            # skip empty rows by checking value is not a string
+            if 'float' in str(type(v)):
+                # check each null count is correct
+                col = isnull.index[i][0]
+                assert self.data_pbc[col].isnull().sum() == v

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -320,18 +320,24 @@ class TestTableOne(object):
         table_groupby = TableOne(df_groupby, columns = ['group','age','weight'],
             categorical = ['group'], groupby=['group'])
         assert (df_groupby['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # sorted
         df_sorted = self.data_groups.copy()
         table_sorted = TableOne(df_sorted, columns = ['group','age','weight'],
             categorical = ['group'], groupby=['group'], sort=True)
         assert (df_sorted['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # pval
         df_pval = self.data_groups.copy()
         table_pval = TableOne(df_pval, columns = ['group','age','weight'],
             categorical = ['group'], groupby=['group'], sort=True, pval=True)
         assert (df_pval['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # pval_adjust
         df_pval_adjust = self.data_groups.copy()
@@ -339,24 +345,32 @@ class TestTableOne(object):
             categorical = ['group'], groupby=['group'], sort=True, pval=True,
             pval_adjust='bonferroni')
         assert (df_pval_adjust['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # labels
         df_labels = self.data_groups.copy()
         table_labels = TableOne(df_labels, columns = ['group','age','weight'],
             categorical = ['group'], groupby=['group'], labels={'age':'age, years'})
         assert (df_labels['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # limit
         df_limit = self.data_groups.copy()
         table_limit = TableOne(df_limit, columns = ['group','age','weight'],
             categorical = ['group'], groupby=['group'], limit=2)
         assert (df_limit['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # nonnormal
         df_nonnormal = self.data_groups.copy()
         table_nonnormal = TableOne(df_nonnormal, columns = ['group','age','weight'],
             categorical = ['group'], groupby=['group'], nonnormal=['age'])
         assert (df_nonnormal['group'] == df_orig['group']).all()
+        assert (df_groupby['age'] == df_orig['age']).all()
+        assert (df_groupby['weight'] == df_orig['weight']).all()
 
         # warnings.simplefilter("default")
 

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -601,7 +601,9 @@ class TestTableOne(object):
 
     @with_setup(setup, teardown)
     def test_check_null_counts_are_correct(self):
-
+        """
+        Test that the isnull column is correctly reporting number of nulls
+        """
         columns = ['age','bili','albumin','ast','platelet','protime',
                    'ascites','hepato','spiders', 'edema','sex','trt']
         categorical = ['ascites','hepato','edema','sex','spiders','trt']

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -170,7 +170,9 @@ class TestTableOne(object):
         categorical=['likesmarmalade']
         table = TableOne(self.data_sample, columns=categorical, categorical=categorical)
 
-        lm = table.cat_describe['overall'].loc['likesmarmalade']
+        lm = table.cat_describe.loc['likesmarmalade']
+        # drop 2nd level for convenience
+        lm.columns = lm.columns.droplevel(level=1)
         notlikefreq = lm.loc[0,'freq']
         notlikepercent = lm.loc[0,'percent']
         likefreq = lm.loc[1,'freq']
@@ -189,7 +191,9 @@ class TestTableOne(object):
         categorical=['likeshoney']
         table = TableOne(self.data_sample, columns=categorical, categorical=categorical)
 
-        lh = table.cat_describe['overall'].loc['likeshoney']
+        lh = table.cat_describe.loc['likeshoney']
+        # drop 2nd level for convenience
+        lh.columns = lh.columns.droplevel(level=1)
         likefreq = lh.loc[1.0,'freq']
         likepercent = lh.loc[1.0,'percent']
 
@@ -248,15 +252,17 @@ class TestTableOne(object):
     @with_setup(setup, teardown)
     def test_categorical_cell_count(self):
         """
-        Ensure that the package runs Fisher exact if cell counts are <=5 and it's a 2x2
+        Check the categorical cell counts are correct
         """
         categorical=list(np.arange(10))
         table = TableOne(self.data_categorical, columns=categorical,categorical=categorical)
-
+        df = table.cat_describe
+        # drop 'overall' level of column index
+        df.columns = df.columns.droplevel(level=1)
         # each column
         for i in np.arange(10):
             # each category should have 100 levels
-            assert table.cat_describe['overall'].loc[i].shape[0] == 100
+            assert df.loc[i].shape[0] == 100
 
     @with_setup(setup, teardown)
     def test_hartigan_diptest_for_modality(self):

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -229,7 +229,7 @@ class TestTableOne(object):
 
         # group2 should be tested because it's a 2x2
         # group3 is a 2x3 so should not be tested
-        assert table._significance_table.loc['group1','ptest'] == 'Fisher''s exact'
+        assert table._significance_table.loc['group1','ptest'] == "Fisher's exact"
         assert table._significance_table.loc['group3','ptest'] == 'Chi-squared (warning: expected count < 5)'
 
     @with_setup(setup, teardown)

--- a/test_tableone.py
+++ b/test_tableone.py
@@ -480,17 +480,6 @@ class TestTableOne(object):
             assert tableone_rows[i+1] == c
 
     @with_setup(setup, teardown)
-    def test_mixed_data_forced_to_numeric(self):
-        """
-        Test case with one column with mixed data that is specified as cont
-        """
-        columns = ['mixed numeric data']
-        table = TableOne(self.data_mixed, columns=columns, categorical=[])
-
-        assert table.tableone.loc[('mixed numeric data',''), 'isnull'] == 1
-
-
-    @with_setup(setup, teardown)
     def test_string_data_as_continuous_error(self):
         """
         Test raising an error when continuous columns contain non-numeric data
@@ -503,23 +492,6 @@ class TestTableOne(object):
         except:
             # unexpected error - raise it
             raise
-
-    @with_setup(setup, teardown)
-    def test_input_data_not_modified(self):
-        """
-        Test to ensure the input dataframe is not modified by the package
-        """
-        df_orig = self.data_groups.copy()
-        df = self.data_groups.copy()
-
-        # turn off warnings for this test
-        warnings.simplefilter("ignore")
-
-        table = TableOne(df, columns=['group'], categorical=[])
-
-        assert (df['group'] == df_orig['group']).all()
-
-        warnings.simplefilter("default")
 
     @with_setup(setup, teardown)
     def test_groupby_with_group_named_isnull(self):


### PR DESCRIPTION
Changes

* coerces data types to numeric if they were not specified as categorical
* raises a warning if all the data in a numeric column are coerced to null
* minor fixes and additional tests