### PR TITLE
support user defined tests. ref #92

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.6.6',
+    version='0.6.7',
 
     description='TableOne',
     long_description=long_description,


### PR DESCRIPTION
Allow the user to specify a statistical test. e.g.

```
# imports
from tableone import TableOne
from scipy import stats
import numpy as np
import pandas as pd
```

```
# create a sample dataset
np.random.seed(12345678)
n1 = 200
n2 = 300

# Baseline distribution
rvs1 = stats.norm.rvs(size=n1, loc=0., scale=1)

# Different to rvs1
rvs2 = stats.norm.rvs(size=n2, loc=0.5, scale=1.5)

# Combine values into a single DataFrame
df1 = pd.DataFrame({'rvs': 'rvs1', 'val': rvs1})
df2 = pd.DataFrame({'rvs': 'rvs2', 'val': rvs2})
different = df1.append(df2)
```

```
# define a custom test that takes a list of numpy array as an argument
# and that returns a test result
def mytest(*args):
    mytest.__name__ = "BOING"
    _, pval= stats.ks_2samp(*args)
    return pval
```

```
t1_diff = TableOne(data=different, columns = ["val"], pval=True,
                           groupby="rvs", pval_test={"val": mytest})

print(t1_diff._significance_table['P-Value'].val)
# 4.6674975515806996e-05

print(stats.ks_2samp(rvs1, rvs2)))
# Ks_2sampResult(statistic=0.20833333333333337, pvalue=4.6674975515806996e-05)
```