### PR TITLE
change pval_adj docs

### DIFF
--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -86,7 +86,7 @@ class TableOne(object):
         are adjusted to account for the number of total tests that were performed.
         These adjustments would be useful when many variables are being screened
         to assess if their distribution varies by the variable in the groupby argument.
-        For a complete list, see documentation for statsmodels multipletests.
+        For a complete list of methods, see documentation for statsmodels multipletests.
         Available methods include ::
 
         `None` : no correction applied.

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -82,6 +82,10 @@ class TableOne(object):
         Display computed P-Values (default: False).
     pval_adjust : str, optional
         Method used to adjust P-Values for multiple testing.
+        The P-values from the unadjusted table (default whe pval=True)
+        are adjusted to account for the number of total tests that were performed.
+        These adjustments would be useful when many variables are being screened
+        to assess if their distribution varies by the variable in the groupby argument.
         For a complete list, see documentation for statsmodels multipletests.
         Available methods include ::
 

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -82,7 +82,7 @@ class TableOne(object):
         Display computed P-Values (default: False).
     pval_adjust : str, optional
         Method used to adjust P-Values for multiple testing.
-        The P-values from the unadjusted table (default whe pval=True)
+        The P-values from the unadjusted table (default when pval=True)
         are adjusted to account for the number of total tests that were performed.
         These adjustments would be useful when many variables are being screened
         to assess if their distribution varies by the variable in the groupby argument.


### PR DESCRIPTION
Minor change to the documentation:

```
        The P-values from the unadjusted table (default when pval=True)
        are adjusted to account for the number of total tests that were performed.
        These adjustments would be useful when many variables are being screened
        to assess if their distribution varies by the variable in the groupby argument.
```