### PR TITLE
Fix anaconda badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ tableone is a package for creating "Table 1" summary statistics for a patient
 population. It was inspired by the R package of the same name by Yoshida and 
 Bohn.
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.837898.svg)](https://doi.org/10.5281/zenodo.837898) [![Documentation Status](https://readthedocs.org/projects/tableone/badge/?version=latest)](https://tableone.readthedocs.io/en/latest/?badge=latest) [![Anaconda-Server Badge](https://anaconda.org/conda-forge/tableone/badges/installer/conda.svg)](https://conda.anaconda.org/conda-forge) [![PyPI version](https://badge.fury.io/py/tableone.svg)](https://badge.fury.io/py/tableone)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.837898.svg)](https://doi.org/10.5281/zenodo.837898)
+[![Documentation Status](https://readthedocs.org/projects/tableone/badge/?version=latest)](https://tableone.readthedocs.io/en/latest/?badge=latest)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/tableone/badges/version.svg)](https://anaconda.org/conda-forge/tableone)
+[![PyPI version](https://badge.fury.io/py/tableone.svg)](https://badge.fury.io/py/tableone)
 
 ## Suggested citation
 


### PR DESCRIPTION
The current list of Anaconda badges is at: https://anaconda.org/conda-forge/tableone/badges/

It looks like the previous badge was discontinued. This pull request updates the badge to point to the new location.