### PR TITLE
Add openpyxl as a dependency. Fixes #122.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-tabulate==0.8.10
-pandas==2.0.0
+anybadge==1.14.0
+Jinja2==3.1.2
 numpy==1.23.2
+openpyxl==3.1.2
+pandas==2.0.0
+pytest-cov==3.0.0
 scipy==1.9.0
 statsmodels==0.13.2
-pytest-cov==3.0.0
-anybadge==1.14.0
+tabulate==0.8.10

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'scipy>=1.7.0',
         'statsmodels>=0.12.1',
         'tabulate>=0.8.10',
-        'Jinja2==3.1.2'
+        'Jinja2==3.1.2',
+        'openpyxl==3.1.2'
         ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
As discussed in https://github.com/tompollard/tableone/issues/122, trying to use `TableOne.to_excel()` raises an error: `ModuleNotFoundError: No module named 'openpyxl'`

This pull request adds openpyxl as a dependency, meaning that people should no longer see the error when calling `.to_excel()`