### PR TITLE
Increase max width to 119 characters for Flake8 style check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 119

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
         pytest -vv --cov-report term-missing --cov tableone | tee coverage-report-${{ matrix.python-version }}.txt


### PR DESCRIPTION
The default max width of 79 characters is limiting. Bump to 119 characters in a new `.flake8` configuration file.