### PR TITLE
Fix deprecated Pandas syntax (up to v2.2.2)

### DIFF
--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -889,8 +889,8 @@ class TableOne:
             df_cont : pandas DataFrame
                 Summarise the continuous variables.
         """
-        aggfuncs = [pd.Series.count, np.mean, np.median, self._std,
-                    self._q25, self._q75, min, max, self._t1_summary]
+        aggfuncs = ['count', 'mean', 'median', self._std,
+                    self._q25, self._q75, 'min', 'max', self._t1_summary]
 
         if self._dip_test:
             aggfuncs.append(self._hartigan_dip)

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -1173,7 +1173,7 @@ class TableOne:
                                 n1=self.cont_describe['count'][p[0]].loc[v],
                                 n2=self.cont_describe['count'][p[1]].loc[v],
                                 unbiased=False)
-                    df[colname.format(p[0], p[1])].loc[v] = smd
+                    df.loc[v, colname.format(p[0], p[1])] = smd
             except AttributeError:
                 pass
 
@@ -1187,7 +1187,7 @@ class TableOne:
                         n1=self.cat_describe.loc[[v]]['freq'][p[0]].sum(),
                         n2=self.cat_describe.loc[[v]]['freq'][p[1]].sum(),
                         unbiased=False)
-                    df[colname.format(p[0], p[1])].loc[v] = smd  # type: ignore
+                    df.loc[v, colname.format(p[0], p[1])] = smd  # type: ignore
             except AttributeError:
                 pass
 

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -119,7 +119,11 @@ def data_mixed(n=20):
 
     mu, sigma = 50, 5
     data_mixed['mixed numeric data'] = np.random.normal(mu, sigma, n)
+
+    # FutureWarning: Setting an item of incompatible dtype is deprecated
+    # and will raise an error in a future version of pandas.
     data_mixed.loc[1, 'mixed numeric data'] = 'could not measure'
+
     return data_mixed
 
 

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -483,7 +483,7 @@ class TestTableOne(object):
 
         # a call to .index.levels[0] automatically sorts the levels
         # instead, call values and use pd.unique as it preserves order
-        tableone_rows = pd.unique([x[0] for x in table.tableone.index.values])
+        tableone_rows = pd.Series([x[0] for x in table.tableone.index.values]).unique()
 
         # default should not sort
         for i, c in enumerate(columns):
@@ -491,7 +491,7 @@ class TestTableOne(object):
             assert tableone_rows[i+1] == c
 
         table = TableOne(df, columns=columns, sort=True, label_suffix=False)
-        tableone_rows = pd.unique([x[0] for x in table.tableone.index.values])
+        tableone_rows = pd.Series([x[0] for x in table.tableone.index.values]).unique()
         for i, c in enumerate(sorted(columns, key=lambda s: s.lower())):
             # i+1 because we skip the first row, 'n'
             assert tableone_rows[i+1] == c

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -967,7 +967,7 @@ class TestTableOne(object):
                    'LOS': '0.121'}
 
         for k in exp_smd:
-            smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'][0]
+            smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'].iloc[0]
             assert smd == exp_smd[k]
 
     def test_compute_standardized_mean_difference_categorical(self, data_pn):
@@ -995,7 +995,7 @@ class TestTableOne(object):
                    'death': '0.017'}
 
         for k in exp_smd:
-            smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'][0]
+            smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'].iloc[0]
             assert smd == exp_smd[k]
 
     def test_order_of_order_categorical_columns(self):


### PR DESCRIPTION
Minor changes to update syntax to address warnings raised when running pytest with Pandas v2.2.2:

```
⏚ [tompollard:~/projects/tableone] [env] main* 5s ± pytest
======================================= test session starts ========================================
platform darwin -- Python 3.9.19, pytest-7.1.2, pluggy-1.0.0
rootdir: /Users/tompollard/projects/tableone
collected 30 items                                                                                 

tests/unit/test_tableone.py ..............................                                   [100%]

========================================= warnings summary =========================================
tests/unit/test_tableone.py: 36 warnings
  /Users/tompollard/projects/tableone/tableone/tableone.py:929: FutureWarning: The provided callable <function mean at 0x103d48790> is currently using DataFrameGroupBy.mean. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "mean" instead.
    df_cont = pd.pivot_table(cont_data,

tests/unit/test_tableone.py: 36 warnings
  /Users/tompollard/projects/tableone/tableone/tableone.py:929: FutureWarning: The provided callable <function median at 0x104646550> is currently using DataFrameGroupBy.median. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "median" instead.
    df_cont = pd.pivot_table(cont_data,

tests/unit/test_tableone.py: 36 warnings
  /Users/tompollard/projects/tableone/tableone/tableone.py:929: FutureWarning: The provided callable <built-in function min> is currently using DataFrameGroupBy.min. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "min" instead.
    df_cont = pd.pivot_table(cont_data,

tests/unit/test_tableone.py: 36 warnings
  /Users/tompollard/projects/tableone/tableone/tableone.py:929: FutureWarning: The provided callable <built-in function max> is currently using DataFrameGroupBy.max. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass the string "max" instead.
    df_cont = pd.pivot_table(cont_data,

tests/unit/test_tableone.py::TestTableOne::test_tableone_row_sort_pn
  /Users/tompollard/projects/tableone/tests/unit/test_tableone.py:486: FutureWarning: unique with argument that is not not a Series, Index, ExtensionArray, or np.ndarray is deprecated and will raise in a future version.
    tableone_rows = pd.unique([x[0] for x in table.tableone.index.values])

tests/unit/test_tableone.py::TestTableOne::test_tableone_row_sort_pn
  /Users/tompollard/projects/tableone/tests/unit/test_tableone.py:494: FutureWarning: unique with argument that is not not a Series, Index, ExtensionArray, or np.ndarray is deprecated and will raise in a future version.
    tableone_rows = pd.unique([x[0] for x in table.tableone.index.values])

tests/unit/test_tableone.py::TestTableOne::test_string_data_as_continuous_error
  /Users/tompollard/projects/tableone/tests/unit/test_tableone.py:122: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value 'could not measure' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
    data_mixed.loc[1, 'mixed numeric data'] = 'could not measure'

tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_continuous
tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_categorical
  /Users/tompollard/projects/tableone/tableone/tableone.py:1176: FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
  You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
  A typical example is when you are setting values in a column of a DataFrame, like:
  
  df["col"][row_indexer] = value
  
  Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  
    df[colname.format(p[0], p[1])].loc[v] = smd

tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_continuous
tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_continuous
tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_continuous
tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_categorical
tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_categorical
tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_categorical
  /Users/tompollard/projects/tableone/tableone/tableone.py:1190: FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
  You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
  A typical example is when you are setting values in a column of a DataFrame, like:
  
  df["col"][row_indexer] = value
  
  Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  
    df[colname.format(p[0], p[1])].loc[v] = smd  # type: ignore

tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_continuous
  /Users/tompollard/projects/tableone/tests/unit/test_tableone.py:970: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'][0]

tests/unit/test_tableone.py::TestTableOne::test_compute_standardized_mean_difference_categorical
  /Users/tompollard/projects/tableone/tests/unit/test_tableone.py:998: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    smd = t.tableone.loc[k, 'Grouped by MechVent']['SMD (0,1)'][0]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```