### PR TITLE
Refactoring for readability: Add _handle_deprecations, _validate_arguments, _validate_data methods.

### DIFF
--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -448,9 +448,9 @@ class TableOne:
             raise InputError("Input data contains duplicate values in the "
                              "index. Reset the index and try again.")
 
-        if columns and not set(columns).issubset(data.columns):  # type: ignore
+        if not set(columns).issubset(data.columns):  # type: ignore
             missing_cols = list(set(columns) - set(data.columns))  # type: ignore
-            raise InputError("""Columns not found in
+            raise InputError("""The following columns were not found in the
                                 dataset: {}""".format(missing_cols))
 
         # check for duplicate columns

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -259,17 +259,15 @@ class TableOne:
             self._normal_test = normal_test
             self._tukey_test = tukey_test
 
-        # if columns are not specified, use all columns
+        self._handle_deprecations()
+
+        # Default assignment for columns if not provided
         if not columns:
             columns = data.columns.values  # type: ignore
 
         self._validate_data(data, columns)
 
-        # groupby should be a string
-        if not groupby:
-            groupby = ''
-        elif groupby and type(groupby) == list:
-            groupby = groupby[0]
+        groupby = self._validate_arguments(groupby)
 
         # nonnormal should be a string
         if not nonnormal:
@@ -431,11 +429,20 @@ class TableOne:
         """
         pass
 
-    def _validate_arguments(self):
+    def _validate_arguments(self, groupby):
         """
         Run validation checks on the arguments.
         """
-        pass
+        if groupby:
+            if isinstance(groupby, list):
+                raise ValueError(f"Invalid 'groupby' type: expected a string, received a list. Use '{groupby[0]}' if it's the intended group.")
+            elif not isinstance(groupby, str):
+                raise TypeError(f"Invalid 'groupby' type: expected a string, received {type(groupby).__name__}.")
+        else:
+            # If 'groupby' is not provided or is explicitly None, treat it as an empty string.
+            groupby = ''
+
+        return groupby
 
     def _validate_data(self, data, columns):
         """

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -220,46 +220,14 @@ class TableOne:
                  tukey_test: bool = False,
                  pval_threshold: Optional[float] = None) -> None:
 
-        # labels is now rename
-        if labels is not None and rename is not None:
-            raise TypeError("TableOne received both labels and rename.")
-        elif labels is not None:
-            warnings.warn("The labels argument is deprecated; use "
-                          "rename instead.", DeprecationWarning)
-            self._alt_labels = labels
-        else:
-            self._alt_labels = rename
+        self._handle_deprecations(labels, rename, isnull, pval_test_name, remarks)
 
-        # isnull is now missing
-        if isnull is not None:
-            warnings.warn("The isnull argument is deprecated; use "
-                          "missing instead.", DeprecationWarning)
-            self._isnull = isnull
-        else:
-            self._isnull = missing
-
-        # pval_test_name is now htest_name
-        if pval_test_name:
-            warnings.warn("The pval_test_name argument is deprecated; use "
-                          "htest_name instead.", DeprecationWarning)
-            self._pval_test_name = pval_test_name
-        else:
-            self._pval_test_name = htest_name
-
-        # remarks are now specified by individual test names
-        if remarks:
-            warnings.warn("The remarks argument is deprecated; specify tests "
-                          "by name instead (e.g. diptest = True)",
-                          DeprecationWarning)
-            self._dip_test = remarks
-            self._normal_test = remarks
-            self._tukey_test = remarks
-        else:
-            self._dip_test = dip_test
-            self._normal_test = normal_test
-            self._tukey_test = tukey_test
-
-        self._handle_deprecations()
+        self._alt_labels = rename
+        self._isnull = missing
+        self._pval_test_name = htest_name
+        self._dip_test = dip_test
+        self._normal_test = normal_test
+        self._tukey_test = tukey_test
 
         # Default assignment for columns if not provided
         if not columns:
@@ -400,11 +368,30 @@ class TableOne:
         if display_all:
             self._set_display_options()
 
-    def _handle_deprecations(self):
+    def _handle_deprecations(self, labels, rename, isnull, pval_test_name, remarks):
         """
         Raise deprecation warnings.
         """
-        pass
+        if labels is not None:
+            warnings.warn("The 'labels' argument of TableOne() is deprecated and will be removed in a future version. "
+                          "Use 'rename' instead.", DeprecationWarning, stacklevel=3)
+
+        if labels is not None and rename is not None:
+            raise TypeError("TableOne received both 'labels' and 'rename'. Please use only 'rename'.")
+
+        if isnull is not None:
+            warnings.warn("The 'isnull' argument is deprecated; use 'missing' instead.",
+                          DeprecationWarning, stacklevel=3)
+
+        # pval_test_name is now htest_name
+        if pval_test_name:
+            warnings.warn("The pval_test_name argument is deprecated; use htest_name instead.", 
+                          DeprecationWarning, stacklevel=3)
+
+        if remarks:
+            warnings.warn("The 'remarks' argument is deprecated; specify tests "
+                          "by name instead (e.g. diptest = True)",
+                          DeprecationWarning, stacklevel=2)
 
     def _validate_arguments(self, groupby, nonnormal, min_max, pval_adjust, order, pval):
         """

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -222,13 +222,6 @@ class TableOne:
 
         self._handle_deprecations(labels, rename, isnull, pval_test_name, remarks)
 
-        self._alt_labels = rename
-        self._isnull = missing
-        self._pval_test_name = htest_name
-        self._dip_test = dip_test
-        self._normal_test = normal_test
-        self._tukey_test = tukey_test
-
         # Default assignment for columns if not provided
         if not columns:
             columns = data.columns.values  # type: ignore
@@ -262,34 +255,40 @@ class TableOne:
         elif order_cats:
             order = d_order_cats  # type: ignore
 
+        self._alt_labels = rename
         self._columns = list(columns)  # type: ignore
         self._continuous = [c for c in columns  # type: ignore
                             if c not in categorical + [groupby]]
         self._categorical = categorical
-        self._nonnormal = nonnormal
+        self._ddof = ddof
+        self._decimals = decimals
+        self._dip_test = dip_test
+        self._groupby = groupby
+        self._htest = htest
+        self._isnull = missing
+        self._label_suffix = label_suffix
+        self._limit = limit
         self._min_max = min_max
+        self._nonnormal = nonnormal
+        self._normal_test = normal_test
+        self._order = order
+        self._overall = overall
         self._pval = pval
         self._pval_adjust = pval_adjust
-        self._htest = htest
-        self._sort = sort
-        self._groupby = groupby
-        # degrees of freedom for standard deviation
-        self._ddof = ddof
-        self._limit = limit
-        self._order = order
-        self._label_suffix = label_suffix
-        self._decimals = decimals
-        self._smd = smd
+        self._pval_test_name = htest_name
         self._pval_threshold = pval_threshold
-        self._overall = overall
+
+        # column names that cannot be contained in a groupby
+        self._reserved_columns = ['Missing', 'P-Value', 'Test',
+                                  'P-Value (adjusted)', 'SMD', 'Overall']
+
         self._row_percent = row_percent
+        self._smd = smd
+        self._sort = sort
+        self._tukey_test = tukey_test
 
         # display notes and warnings below the table
         self._warnings = {}
-
-        # output column names that cannot be contained in a groupby
-        self._reserved_columns = ['Missing', 'P-Value', 'Test',
-                                  'P-Value (adjusted)', 'SMD', 'Overall']
 
         if self._groupby:
             self._groupbylvls = sorted(data.groupby(groupby).groups.keys())  # type: ignore

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -146,7 +146,7 @@ class TestTableOne(object):
 
         columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
         categorical = ['ICU', 'death']
-        groupby = ['death']
+        groupby = 'death'
         nonnormal = ['Age']
         TableOne(data_pn, columns=columns,
                  categorical=categorical, groupby=groupby,
@@ -353,7 +353,7 @@ class TestTableOne(object):
         df_groupby = data_groups.copy()
         TableOne(df_groupby,
                  columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'])
+                 categorical=['group'], groupby='group')
         assert (df_groupby['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
         assert (df_groupby['weight'] == df_orig['weight']).all()
@@ -361,7 +361,7 @@ class TestTableOne(object):
         # sorted
         df_sorted = data_groups.copy()
         TableOne(df_sorted, columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
+                 categorical=['group'], groupby='group',
                  sort=True)
         assert (df_sorted['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
@@ -370,7 +370,7 @@ class TestTableOne(object):
         # pval
         df_pval = data_groups.copy()
         TableOne(df_pval, columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
+                 categorical=['group'], groupby='group',
                  sort=True, pval=True)
         assert (df_pval['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
@@ -381,7 +381,7 @@ class TestTableOne(object):
         TableOne(df_pval_adjust,
                  columns=['group', 'age', 'weight'],
                  categorical=['group'],
-                 groupby=['group'], sort=True, pval=True,
+                 groupby='group', sort=True, pval=True,
                  pval_adjust='bonferroni')
         assert (df_pval_adjust['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
@@ -391,7 +391,7 @@ class TestTableOne(object):
         df_labels = data_groups.copy()
         TableOne(df_labels,
                  columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
+                 categorical=['group'], groupby='group',
                  rename={'age': 'age, years'})
         assert (df_labels['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
@@ -401,7 +401,7 @@ class TestTableOne(object):
         df_limit = data_groups.copy()
         TableOne(df_limit,
                  columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
+                 categorical=['group'], groupby='group',
                  limit=2)
         assert (df_limit['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
@@ -411,7 +411,7 @@ class TestTableOne(object):
         df_nonnormal = data_groups.copy()
         TableOne(df_nonnormal,
                  columns=['group', 'age', 'weight'],
-                 categorical=['group'], groupby=['group'],
+                 categorical=['group'], groupby='group',
                  nonnormal=['age'])
         assert (df_nonnormal['group'] == df_orig['group']).all()
         assert (df_groupby['age'] == df_orig['age']).all()
@@ -517,7 +517,7 @@ class TestTableOne(object):
         """
         df = data_pn.copy()
         columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
-        groupby = ['death']
+        groupby = 'death'
 
         table = TableOne(df, columns=columns, groupby=groupby, pval=True,
                          htest_name=True, overall=False)
@@ -553,7 +553,7 @@ class TestTableOne(object):
         """
         columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
         categorical = ['ICU', 'death']
-        groupby = ['death']
+        groupby = 'death'
 
         # test when not grouping
         table = TableOne(data_pn, columns=columns,
@@ -612,7 +612,7 @@ class TestTableOne(object):
         """
         columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
         categorical = ['ICU', 'death']
-        groupby = ['death']
+        groupby = 'death'
         nonnormal = ['Age']
 
         # no decimals argument
@@ -692,7 +692,7 @@ class TestTableOne(object):
         """
         columns = ['Age', 'SysABP', 'Height', 'Weight', 'ICU', 'death']
         categorical = ['ICU', 'death']
-        groupby = ['death']
+        groupby = 'death'
         nonnormal = ['Age']
 
         # decimals = 1
@@ -1065,7 +1065,7 @@ class TestTableOne(object):
         nonnormal = ['Age']
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = 'death'
 
         t1 = TableOne(data_pn, columns=columns, categorical=categorical,
                       groupby=groupby, nonnormal=nonnormal, decimals=decimals,
@@ -1096,7 +1096,7 @@ class TestTableOne(object):
         nonnormal = ['Age']
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = 'death'
         group = "Grouped by death"
 
         # row_percent = False
@@ -1146,7 +1146,7 @@ class TestTableOne(object):
         nonnormal = ['Age']
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = 'death'
         group = "Grouped by death"
 
         # row_percent = True
@@ -1196,7 +1196,7 @@ class TestTableOne(object):
         nonnormal = ['Age']
 
         # optionally, a categorical variable for stratification
-        groupby = ['death']
+        groupby = 'death'
         group = "Grouped by death"
 
         # row_percent = True

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -434,7 +434,7 @@ class TestTableOne(object):
         tableone_columns = list(table.tableone.columns.levels[1])
 
         table = TableOne(df, columns=columns, groupby=groupby, pval=True,
-                         pval_adjust='b')
+                         pval_adjust='bonferroni')
         tableone_columns = (tableone_columns +
                             list(table.tableone.columns.levels[1]))
         tableone_columns = np.unique(tableone_columns)
@@ -445,7 +445,7 @@ class TestTableOne(object):
             # for each output column name in tableone, try them as a group
             df.loc[0:20, 'ICU'] = c
             if 'adjust' in c:
-                pval_adjust = 'b'
+                pval_adjust = 'bonferroni'
             else:
                 pval_adjust = None
 
@@ -836,7 +836,7 @@ class TestTableOne(object):
         # catch the pval_adjust=True
         with warnings.catch_warnings(record=False):
             warnings.simplefilter('ignore', category=UserWarning)
-            TableOne(df, groupby="even", pval=True, pval_adjust=True)
+            TableOne(df, groupby="even", pval=True, pval_adjust='bonferroni')
 
         for k in pvals_expected:
             assert (t1.tableone.loc[k][group][col].values[0] ==


### PR DESCRIPTION
This pull request moves some of the content from __init__ into the following methods:

- `_handle_deprecations`: reports on deprecated arguments
- `_validate_arguments`: runs checks on the input arguments
- `_validate_data`: runs checks on the input dataframe

In addition, support for the following arguments has been dropped: `labels`, `isnull`, `pval_test_name`, `remarks`.