### PR TITLE
Remove coverage. Ensure pytest returns failure code on fail.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,10 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
-        include:
-          - python-version: "3.10"
-            coverage: 1
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,29 +27,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest pyright
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
+        # Stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        # Exit-zero treats all errors as warnings.
         flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Type check with pyright
       run: |
         pyright tableone
     - name: Test with pytest
       run: |
-        pytest -vv --cov-report term-missing --cov tableone | tee coverage-report-${{ matrix.python-version }}.txt
-    - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage-report
-        path: coverage-report-${{ matrix.python-version }}.txt
-      # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
-    - name: Generate coverage badge
-      if: ${{ matrix.coverage }}
-      run: |
-        value=$(awk '$1 == "TOTAL" {print $NF+0}' coverage-report-${{ matrix.python-version }}.txt)
-        anybadge --value=$value --file coverage.svg coverage
+        pytest -vv


### PR DESCRIPTION
Currently the GitHub "[python-package.yml](https://github.com/tompollard/tableone/blob/main/.github/workflows/python-package.yml)" workflow is getting piped into a coverage report. As a result, if tests fail pytest is not returning an error code. This pull request ensures that failed tests are clearly reported in GitHub (and removes coverage in the process).