### PR TITLE
Add include_null argument to handle nulls for categorical values. Ref #114.

### DIFF
--- a/tableone/preprocessors.py
+++ b/tableone/preprocessors.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from tableone.exceptions import InputError
 
@@ -99,3 +100,18 @@ def get_groups(data, groupby, order, reserved_columns):
         groupbylvls = ['Overall']
 
     return groupbylvls
+
+
+def handle_categorical_nulls(df: pd.DataFrame, null_value: str = 'None') -> pd.DataFrame:
+    """
+    Convert None/Null values in specified categorical columns to a given string,
+    so they are treated as an additional category.
+
+    Parameters:
+    - data (pd.DataFrame): The DataFrame containing the categorical data.
+    - null_value (str): The string to replace null values with. Default is 'None'.
+
+    Returns:
+    - pd.DataFrame: The modified DataFrame if not inplace, otherwise None.
+    """
+    return df.fillna(null_value)

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -169,9 +169,9 @@ class TableOne:
         Run Tukey's test for far outliers. If variables are found to
         have far outliers, a remark will be added below the Table 1.
         (default: False)
-    auto_fill_nulls : bool, optional
-        Attempt to automatically handle None/Null values in categorical columns
-        by treating them as a category named 'None'. (default: True)
+    include_null : bool, optional
+        Include None/Null values for categorical variables by treating them as a
+        category level. (default: True)
 
 
     Attributes
@@ -225,7 +225,7 @@ class TableOne:
                  dip_test: bool = False, normal_test: bool = False,
                  tukey_test: bool = False,
                  pval_threshold: Optional[float] = None,
-                 auto_fill_nulls: Optional[bool] = True) -> None:
+                 include_null: Optional[bool] = True) -> None:
 
         # Warn about deprecated parameters
         handle_deprecated_parameters(labels, isnull, pval_test_name, remarks)
@@ -240,7 +240,7 @@ class TableOne:
                                                htest, missing, ddof, rename, sort, limit, order,
                                                label_suffix, decimals, smd, overall, row_percent,
                                                dip_test, normal_test, tukey_test, pval_threshold,
-                                               auto_fill_nulls)
+                                               include_null)
 
         # Initialize intermediate tables
         self.initialize_intermediate_tables()
@@ -282,12 +282,12 @@ class TableOne:
                                    htest, missing, ddof, rename, sort, limit, order,
                                    label_suffix, decimals, smd, overall, row_percent, 
                                    dip_test, normal_test, tukey_test, pval_threshold,
-                                   auto_fill_nulls):
+                                   include_null):
         """
         Initialize attributes.
         """
         self._alt_labels = rename
-        self._auto_fill_nulls = auto_fill_nulls
+        self._include_null = include_null
         self._columns = columns if columns else data.columns.to_list()  # type: ignore
         self._categorical = detect_categorical(data[self._columns], groupby) if categorical is None else categorical
         if continuous:
@@ -318,7 +318,7 @@ class TableOne:
         self._tukey_test = tukey_test
         self._warnings = {}
 
-        if self._categorical and self._auto_fill_nulls:
+        if self._categorical and self._include_null:
             data[self._categorical] = handle_categorical_nulls(data[self._categorical])
 
         self._groupbylvls = get_groups(data, self._groupby, self._order, self._reserved_columns)
@@ -347,7 +347,7 @@ class TableOne:
         self.input_validator.validate(self._groupby, self._nonnormal, self._min_max,  # type: ignore
                                       self._pval_adjust, self._order, self._pval,  # type: ignore
                                       self._columns, self._categorical, self._continuous)  # type: ignore
-        self.data_validator.validate(data, self._columns, self._categorical, self._auto_fill_nulls)  # type: ignore
+        self.data_validator.validate(data, self._columns, self._categorical, self._include_null)  # type: ignore
 
     def create_intermediate_tables(self, data):
         """
@@ -366,6 +366,7 @@ class TableOne:
                                                                     self._categorical,
                                                                     self._decimals,
                                                                     self._row_percent,
+                                                                    self._include_null,
                                                                     groupby=None,
                                                                     groupbylvls=['Overall'])
 
@@ -385,6 +386,7 @@ class TableOne:
                                                                 self._categorical,
                                                                 self._decimals,
                                                                 self._row_percent,
+                                                                self._include_null,
                                                                 groupby=self._groupby,
                                                                 groupbylvls=self._groupbylvls)
 
@@ -413,6 +415,7 @@ class TableOne:
                                                           self._overall,
                                                           self.cat_describe,
                                                           self._categorical,
+                                                          self._include_null,
                                                           self._pval,
                                                           self._pval_adjust,
                                                           self.htest_table,

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -329,10 +329,10 @@ class TableOne:
         self.input_validator = InputValidator()
 
     def validate_data(self, data):
-        self.data_validator.validate(data, self._columns)  # type: ignore
         self.input_validator.validate(self._groupby, self._nonnormal, self._min_max,  # type: ignore
                                       self._pval_adjust, self._order, self._pval,  # type: ignore
                                       self._columns, self._categorical, self._continuous)  # type: ignore
+        self.data_validator.validate(data, self._columns, self._categorical)  # type: ignore
 
     def create_intermediate_tables(self, data):
         """

--- a/tableone/validators.py
+++ b/tableone/validators.py
@@ -10,7 +10,8 @@ class DataValidator:
         """Initialize the DataValidator class."""
         pass
 
-    def validate(self, data: pd.DataFrame, columns: list) -> None:
+    def validate(self, data: pd.DataFrame, columns: list,
+                 categorical: Optional[List[str]] = None) -> None:
         """
         Check the input dataset for obvious issues.
 
@@ -22,6 +23,22 @@ class DataValidator:
         self.check_unique_index(data)
         self.check_columns_exist(data, columns)
         self.check_duplicate_columns(data, columns)
+        if categorical:
+            self.check_categorical_none(data, categorical)
+
+    def check_categorical_none(self, data: pd.DataFrame, categorical: List[str]):
+        """
+        Ensure that categorical columns do not contain None values.
+
+        Parameters:
+        data (pd.DataFrame): The DataFrame to check.
+        categorical (List[str]): The list of categorical columns to validate.
+        """
+        none_containing_cols = [col for col in categorical if data[col].isnull().any()]
+        if none_containing_cols:
+            raise InputError(f"The following categorical columns contains one or more 'None' values. These values "
+                             f"must be converted to a string before processing: {none_containing_cols}. e.g. use "
+                             f"data[categorical_columns] = data[categorical_columns].fillna('None')")
 
     def validate_input(self, data: pd.DataFrame):
         if not isinstance(data, pd.DataFrame):

--- a/tableone/validators.py
+++ b/tableone/validators.py
@@ -12,7 +12,7 @@ class DataValidator:
 
     def validate(self, data: pd.DataFrame, columns: list,
                  categorical: list,
-                 auto_fill_nulls: bool) -> None:
+                 include_null: bool) -> None:
         """
         Check the input dataset for obvious issues.
 
@@ -24,23 +24,6 @@ class DataValidator:
         self.check_unique_index(data)
         self.check_columns_exist(data, columns)
         self.check_duplicate_columns(data, columns)
-        if categorical and not auto_fill_nulls:
-            self.check_categorical_none(data, categorical)
-
-    def check_categorical_none(self, data: pd.DataFrame, categorical: List[str]):
-        """
-        Ensure that categorical columns do not contain None values.
-
-        Parameters:
-        data (pd.DataFrame): The DataFrame to check.
-        categorical (List[str]): The list of categorical columns to validate.
-        """
-        contains_none = [col for col in categorical if data[col].isnull().any()]
-        if contains_none:
-            raise InputError(f"The following categorical columns contains one or more null values: {contains_none}. "
-                             f"These must be converted to strings before processing. Either set "
-                             f"`auto_fill_nulls = True` or manually convert nulls to strings with: "
-                             f"data[categorical_columns] = data[categorical_columns].fillna('None')")
 
     def validate_input(self, data: pd.DataFrame):
         if not isinstance(data, pd.DataFrame):

--- a/tableone/validators.py
+++ b/tableone/validators.py
@@ -11,7 +11,8 @@ class DataValidator:
         pass
 
     def validate(self, data: pd.DataFrame, columns: list,
-                 categorical: Optional[List[str]] = None) -> None:
+                 categorical: list,
+                 auto_fill_nulls: bool) -> None:
         """
         Check the input dataset for obvious issues.
 
@@ -23,7 +24,7 @@ class DataValidator:
         self.check_unique_index(data)
         self.check_columns_exist(data, columns)
         self.check_duplicate_columns(data, columns)
-        if categorical:
+        if categorical and not auto_fill_nulls:
             self.check_categorical_none(data, categorical)
 
     def check_categorical_none(self, data: pd.DataFrame, categorical: List[str]):
@@ -34,10 +35,11 @@ class DataValidator:
         data (pd.DataFrame): The DataFrame to check.
         categorical (List[str]): The list of categorical columns to validate.
         """
-        none_containing_cols = [col for col in categorical if data[col].isnull().any()]
-        if none_containing_cols:
-            raise InputError(f"The following categorical columns contains one or more 'None' values. These values "
-                             f"must be converted to a string before processing: {none_containing_cols}. e.g. use "
+        contains_none = [col for col in categorical if data[col].isnull().any()]
+        if contains_none:
+            raise InputError(f"The following categorical columns contains one or more null values: {contains_none}. "
+                             f"These must be converted to strings before processing. Either set "
+                             f"`auto_fill_nulls = True` or manually convert nulls to strings with: "
                              f"data[categorical_columns] = data[categorical_columns].fillna('None')")
 
     def validate_input(self, data: pd.DataFrame):

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -216,7 +216,7 @@ class TestTableOne(object):
         """
         categorical = ['likeshoney']
         table = TableOne(data_sample, columns=categorical,
-                         categorical=categorical)
+                         categorical=categorical, include_null=False)
 
         lh = table.cat_describe.loc['likeshoney']
 
@@ -796,7 +796,8 @@ class TestTableOne(object):
 
         # create tableone
         t1 = TableOne(df, label_suffix=False,
-                      categorical=['basket1', 'basket2', 'basket3', 'basket4'])
+                      categorical=['basket1', 'basket2', 'basket3', 'basket4'],
+                      include_null=False)
 
         assert all(t1.tableone.loc['basket1'].index == ['apple', 'banana',
                                                         'durian', 'lemon',
@@ -1028,7 +1029,7 @@ class TestTableOne(object):
 
         # if a custom order is not specified, the categorical order
         # specified above should apply
-        t1 = TableOne(data, label_suffix=False)
+        t1 = TableOne(data, label_suffix=False, include_null=False)
 
         t1_expected_order = {'month': ["feb", "jan", "mar", "apr"],
                              'day': ["wed", "thu", "mon", "tue"]}
@@ -1039,7 +1040,7 @@ class TestTableOne(object):
                     t1_expected_order[k])
 
         # if a desired order is set, it should override the order
-        t2 = TableOne(data, order=order, label_suffix=False)
+        t2 = TableOne(data, order=order, label_suffix=False, include_null=False)
 
         t2_expected_order = {'month': ["jan", "feb", "mar", "apr"],
                              'day': ["mon", "tue", "wed", "thu"]}
@@ -1104,7 +1105,7 @@ class TestTableOne(object):
         t1 = TableOne(data_pn, columns=columns,
                       categorical=categorical, groupby=groupby,
                       nonnormal=nonnormal, decimals=decimals,
-                      row_percent=False)
+                      row_percent=False, include_null=False)
 
         row1 = list(t1.tableone.loc["MechVent, n (%)"][group].values[0])
         row1_expect = [0, '540 (54.0)', '468 (54.2)', '72 (52.9)']
@@ -1154,7 +1155,7 @@ class TestTableOne(object):
         t2 = TableOne(data_pn, columns=columns,
                       categorical=categorical, groupby=groupby,
                       nonnormal=nonnormal, decimals=decimals,
-                      row_percent=True)
+                      row_percent=True, include_null=False)
 
         row1 = list(t2.tableone.loc["MechVent, n (%)"][group].values[0])
         row1_expect = [0, '540 (100.0)', '468 (86.7)', '72 (13.3)']
@@ -1204,7 +1205,7 @@ class TestTableOne(object):
         t1 = TableOne(data_pn, columns=columns, overall=False,
                       categorical=categorical, groupby=groupby,
                       nonnormal=nonnormal, decimals=decimals,
-                      row_percent=True)
+                      row_percent=True, include_null=False)
 
         row1 = list(t1.tableone.loc["MechVent, n (%)"][group].values[0])
         row1_expect = [0, '468 (86.7)', '72 (13.3)']


### PR DESCRIPTION
Adds a new `include_null` argument. If set to True, null values for categorical values will be treated as a category level:

```
    include_null : bool, optional
        Include None/Null values for categorical variables by treating them as a
        category level. (default: True)
```

This fixes the issue described in https://github.com/tompollard/tableone/issues/114.