### PR TITLE
bump Jinja2 from 3.1.2 to 3.1.4.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'scipy>=1.10.1',
         'statsmodels>=0.14.1',
         'tabulate>=0.9.0',
-        'Jinja2==3.1.2',
+        'Jinja2==3.1.4',
         'openpyxl==3.1.2'
         ],
 


### PR DESCRIPTION
Bump Jinja2 from 3.1.2 to 3.1.4 (the latest stable version).

https://pypi.org/project/Jinja2/