### PR TITLE
Bump scipy from 1.10.1 to 1.13.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ openpyxl==3.1.2
 pandas==2.0.3
 pyright==1.1.305
 pytest-cov==3.0.0
-scipy==1.10.1
+scipy==1.13.1
 statsmodels==0.14.1
 tabulate==0.9.0


### PR DESCRIPTION
Bump scipy from 1.10.1 to 1.13.1.