### PR TITLE
Fix creation of categorical tables when missing category levels

### DIFF
--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -1281,3 +1281,37 @@ def test_smd_with_missing_category_level_in_group():
     smd = table.tableone.loc['color, n (%)', 'Grouped by group']['SMD (0,1)'].iloc[0]
 
     assert isinstance(smd, str) and smd.lower() != 'nan', "SMD should be computed and not be NaN"
+
+
+def test_missing_column_appears_in_first_row():
+    """
+    Test that the 'Missing' column is correctly populated only in the first
+    row of each categorical variable.
+    """
+    df = pd.DataFrame({
+        'group': [0]*5 + [1]*5,
+        'color': ['red', 'red', 'blue', 'blue', None,
+                  'red', 'red', 'blue', 'blue', 'blue']
+    })
+
+    table = TableOne(df,
+                     columns=['color'],
+                     categorical=['color'],
+                     groupby='group',
+                     include_null=False)
+
+    t1 = table.tableone
+
+    assert 'Missing' in t1['Grouped by group'].columns
+
+    # Extract rows for "color" variable
+    color_rows = t1.loc['color, n (%)', :]
+
+    # First row should contain a valid Missing value
+    assert color_rows.at[color_rows.index[0],
+                         ('Grouped by group', 'Missing')] == 1
+
+    # Remaining rows should have NaN
+    for i in range(1, len(color_rows)):
+        assert color_rows.at[color_rows.index[i],
+                             ('Grouped by group', 'Missing')] == ''

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -1260,3 +1260,24 @@ class TestTableOne(object):
 
         expected = '1 (20.0)'
         assert t.tableone.loc["sex, n (%)", "None"]["Overall"] == expected
+
+
+def test_smd_with_missing_category_level_in_group():
+    """
+    Test that SMD is not NaN when one group is missing a level of a categorical variable.
+    This corresponds to GitHub issue #182.
+    """
+    df = pd.DataFrame({
+        'group': [0]*5 + [1]*5,
+        'color': ['red', 'red', 'blue', 'blue', 'green',
+                  'red', 'red', 'blue', 'blue', 'blue']
+    })
+
+    # Force color to be categorical with all expected levels
+    df['color'] = pd.Categorical(df['color'], categories=['red', 'blue', 'green'])
+
+    table = TableOne(df, columns=['color'], categorical=['color'], groupby='group', smd=True)
+
+    smd = table.tableone.loc['color, n (%)', 'Grouped by group']['SMD (0,1)'].iloc[0]
+
+    assert isinstance(smd, str) and smd.lower() != 'nan', "SMD should be computed and not be NaN"


### PR DESCRIPTION
As discussed in https://github.com/tompollard/tableone/issues/182, there was an issue with summary tables that were created when a level of a categorical variable was missing in one of the "group by" groups. This led to two main problems:

- Inconsistent indexing across groups, which broke alignment during standardized mean difference (SMD) computation.
- Dropped rows for category levels that existed in the full dataset, but were absent in some groups.

This pull request resolves issue #182 by ensuring that categorical variables are included in the summary table even when they are not present within a grouping.