### PR TITLE
Fix TypeError when computing p-values with missing categorical values

### DIFF
--- a/tableone/preprocessors.py
+++ b/tableone/preprocessors.py
@@ -102,23 +102,22 @@ def get_groups(data, groupby, order, reserved_columns):
     return groupbylvls
 
 
-def handle_categorical_nulls(df: pd.DataFrame, null_value: str = 'None') -> pd.DataFrame:
+def handle_categorical_nulls(df: pd.DataFrame, categorical: list, null_value: str = 'None') -> pd.DataFrame:
     """
     Convert None/Null values in specified categorical columns to a given string,
     so they are treated as an additional category.
 
     Parameters:
     - data (pd.DataFrame): The DataFrame containing the categorical data.
+    - categorical (list): List of categorical variables.
     - null_value (str): The string to replace null values with. Default is 'None'.
 
     Returns:
-    - pd.DataFrame: The modified DataFrame if not inplace, otherwise None.
+    - pd.DataFrame: The modified DataFrame.
     """
-    for column in df.columns:
+    df = df.copy()
+    for column in categorical:
         if df[column].isnull().any():
-            if df[column].dtype.name == 'category':
-                # Add 'None' to categories if it isn't already there
-                if null_value not in df[column].cat.categories:
-                    df.loc[:, column] = df[column].cat.add_categories(null_value)
-            df.loc[:, column] = df[column].fillna(null_value)
+            df[column] = df[column].astype(object).astype(str)
+            df[column] = df[column].replace('nan', null_value)
     return df

--- a/tableone/tableone.py
+++ b/tableone/tableone.py
@@ -313,7 +313,7 @@ class TableOne:
         self._warnings = {}
 
         if self._categorical and self._include_null:
-            data[self._categorical] = handle_categorical_nulls(data[self._categorical])
+            data[self._categorical] = handle_categorical_nulls(data[self._categorical], self._categorical)
 
         self._groupbylvls = get_groups(data, self._groupby, self._order, self._reserved_columns)
 

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -1315,3 +1315,12 @@ def test_missing_column_appears_in_first_row():
     for i in range(1, len(color_rows)):
         assert color_rows.at[color_rows.index[i],
                              ('Grouped by group', 'Missing')] == ''
+
+
+def test_pval_with_numeric_missing():
+    df = pd.DataFrame({
+        'group': ['A', 'B', 'A', 'B', 'A'],
+        'numeric_cat': [1, 2, np.nan, 2, 1]
+    })
+    t1 = TableOne(df, columns=['numeric_cat'], categorical=['numeric_cat'], groupby='group', pval=True)
+    assert 'p-value' in t1.tableone.columns

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -9,6 +9,7 @@ from scipy import stats
 from tableone import TableOne, load_dataset
 from tableone.validators import InputError
 from tableone.modality import hartigan_diptest, generate_data
+from tableone.preprocessors import handle_categorical_nulls
 
 seed = 12345
 
@@ -1323,4 +1324,72 @@ def test_pval_with_numeric_missing():
         'numeric_cat': [1, 2, np.nan, 2, 1]
     })
     t1 = TableOne(df, columns=['numeric_cat'], categorical=['numeric_cat'], groupby='group', pval=True)
-    assert 'p-value' in t1.tableone.columns
+    assert ('Grouped by group', 'P-Value') in t1.tableone.columns
+
+
+def test_pval_numeric_categorical_with_nan():
+    df = pd.DataFrame({
+        'group': ['A', 'B', 'A', 'B', 'A'],
+        'numcat': [1, 2, np.nan, 2, 1]
+    })
+    t1 = TableOne(df, columns=['numcat'], categorical=['numcat'], groupby='group', pval=True)
+    assert ('Grouped by group', 'P-Value') in t1.tableone.columns
+    assert 'None' in t1.tableone.index.get_level_values(1)
+
+
+def test_pval_float_categorical_with_nan():
+    df = pd.DataFrame({
+        'group': ['A', 'B', 'A', 'B', 'A'],
+        'floatcat': [1.1, 2.2, np.nan, 2.2, 1.1]
+    })
+    t1 = TableOne(df, columns=['floatcat'], categorical=['floatcat'], groupby='group', pval=True)
+    assert ('Grouped by group', 'P-Value') in t1.tableone.columns
+    assert 'None' in t1.tableone.index.get_level_values(1)
+
+
+def test_pval_str_categorical_with_nan():
+    df = pd.DataFrame({
+        'group': ['A', 'B', 'A', 'B', 'A'],
+        'strcat': ['x', 'y', np.nan, 'y', 'x']
+    })
+    t1 = TableOne(df, columns=['strcat'], categorical=['strcat'], groupby='group', pval=True)
+    assert ('Grouped by group', 'P-Value') in t1.tableone.columns
+    assert 'None' in t1.tableone.index.get_level_values(1)
+
+
+def test_all_missing_categorical_column():
+    df = pd.DataFrame({
+        'group': ['A', 'B', 'A'],
+        'missingcat': [np.nan, np.nan, np.nan]
+    })
+    t1 = TableOne(df, columns=['missingcat'], categorical=['missingcat'], groupby='group', pval=True)
+    assert ('Grouped by group', 'P-Value') in t1.tableone.columns
+    assert 'None' in t1.tableone.index.get_level_values(1)
+
+
+def test_sorted_category_handling():
+    df = pd.DataFrame({
+        'group': ['A', 'B', 'A', 'B', 'A'],
+        'mixedcat': ['dog', np.nan, 'cat', 'rabbit', 'cat']
+    })
+    t1 = TableOne(df, columns=['mixedcat'], categorical=['mixedcat'], groupby='group', pval=True)
+    # Check if categories are sorted and include 'None'
+    categories = t1.tableone.index.get_level_values(1).tolist()
+    assert categories == sorted(categories, key=str)
+    assert 'None' in categories
+
+
+def test_handle_categorical_nulls_with_numeric_category():
+    df = pd.DataFrame({'x': [1, 2, np.nan]})
+    result = handle_categorical_nulls(df, categorical=['x'])
+    assert set(result['x'].unique()) == {'1.0', '2.0', 'None'}
+
+
+def test_handle_categorical_nulls_does_not_affect_continuous():
+    df = pd.DataFrame({
+        'cat': ['a', 'b', np.nan],
+        'cont': [1.0, 2.0, 3.0]
+    })
+    result = handle_categorical_nulls(df, categorical=['cat'])
+    assert result['cont'].dtype == float
+    assert result['cat'].iloc[2] == 'None'


### PR DESCRIPTION
This PR fixes a `TypeError` that occurs when computing p-values for categorical variables containing missing values. The error arises because missing values are replaced with the string 'None', leading to mixed-type categories (e.g.`int` and `str`) which cannot be sorted during internal processing (ref #161 and #160).

Previously, the following code would raise `TypeError: '<' not supported between instances of 'str' and 'int'`:
```
from tableone import TableOne
import pandas as pd
import numpy as np

df = pd.DataFrame({
    'group': ['A', 'B', 'A', 'B', 'A'],
    'numeric_cat': [1, 2, np.nan, 2, 1]
})

t1 = TableOne(df, columns=['numeric_cat'], categorical=['numeric_cat'], groupby='group', pval=True)
print(t1.tableone)

```

The fixes are:

- Modified `handle_categorical_nulls()` to convert entire columns to string before replacing nulls with 'None', avoiding mixed-type category issues.
- Added a key=str argument when sorting categories to prevent sorting errors in edge cases.