### PR TITLE
Add ttest_equal_var argument to control t-test variance assumption

### DIFF
--- a/tableone/statistics.py
+++ b/tableone/statistics.py
@@ -115,7 +115,8 @@ class Statistics:
                 is_normal: bool,
                 min_observed: int,
                 catlevels: list,
-                h_test: dict):
+                h_test: dict,
+                ttest_equal_var: bool):
         """
         Compute P-Values.
 
@@ -165,9 +166,9 @@ class Statistics:
         # continuous
         if (is_continuous and is_normal and len(grouped_data) == 2
                 and min_observed >= 2):
-            ptest = 'Two Sample T-test'
+            ptest = 'Welch’s T-test' if not ttest_equal_var else 'Pooled T-test'
             test_stat, pval = stats.ttest_ind(*grouped_data.values(),
-                                              equal_var=False,
+                                              equal_var=ttest_equal_var,
                                               nan_policy="omit")
         elif is_continuous and is_normal:
             # normally distributed

--- a/tableone/statistics.py
+++ b/tableone/statistics.py
@@ -114,7 +114,6 @@ class Statistics:
                 is_categorical: bool,
                 is_normal: bool,
                 min_observed: int,
-                catlevels: list,
                 h_test: dict,
                 ttest_equal_var: bool):
         """
@@ -134,8 +133,6 @@ class Statistics:
                 True if the variable is normally distributed.
             min_observed : int
                 Minimum number of values across groups for the variable.
-            catlevels : list
-                Sorted list of levels for categorical variables.
 
         Returns
         ----------

--- a/tableone/tables.py
+++ b/tableone/tables.py
@@ -31,7 +31,8 @@ class Tables:
                            groupbylvls,
                            htest,
                            pval,
-                           pval_adjust) -> pd.DataFrame:
+                           pval_adjust,
+                           ttest_equal_var) -> pd.DataFrame:
         """
         Create a table containing P-Values for significance tests. Add features
         of the distributions and the P-Values to the dataframe.
@@ -89,7 +90,8 @@ class Tables:
             (df.loc[v, 'P-Value'],
              df.loc[v, 'Test'],
              warning_msg) = self.statistics._p_test(v, grouped_data, is_continuous, is_categorical,  # type: ignore
-                                                    is_normal,  min_observed, catlevels, htest)  # type: ignore
+                                                    is_normal,  min_observed, catlevels, htest,
+                                                    ttest_equal_var)  # type: ignore
 
             # TODO: Improve method for handling these warnings.
             # Write to logfile?

--- a/tableone/tables.py
+++ b/tableone/tables.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Any
 
 import numpy as np
 import pandas as pd
@@ -58,6 +58,9 @@ class Tables:
         df['nonnormal'] = np.where(df.index.isin(nonnormal), True, False)
 
         # list values for each variable, grouped by groupby levels
+        min_observed = 0
+        catlevels = None
+
         for v in df.index:
             is_continuous = df.loc[v]['continuous']
             is_categorical = ~df.loc[v]['continuous']
@@ -90,8 +93,7 @@ class Tables:
             (df.loc[v, 'P-Value'],
              df.loc[v, 'Test'],
              warning_msg) = self.statistics._p_test(v, grouped_data, is_continuous, is_categorical,  # type: ignore
-                                                    is_normal,  min_observed, catlevels, htest,
-                                                    ttest_equal_var)  # type: ignore
+                                                    is_normal,  min_observed, htest, ttest_equal_var)  # type: ignore
 
             # TODO: Improve method for handling these warnings.
             # Write to logfile?

--- a/tableone/tables.py
+++ b/tableone/tables.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Optional
 
 import numpy as np
 import pandas as pd

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -1411,8 +1411,22 @@ def test_pval_digits_custom_formatting():
     pval = t2.tableone['Grouped by group']['P-Value'].iloc[1]
     assert pval == '0.233*'
 
-
     t3 = TableOne(df, columns=['y'], continuous=['y'], groupby='group', pval=True, pval_digits=1,
                   pval_threshold=0.3)
     pval = t3.tableone['Grouped by group']['P-Value'].iloc[1]
     assert pval == '<0.1*'
+
+
+def test_ttest_equal_var_flag():
+    df = pd.DataFrame({
+        'group': ['A', 'A', 'A', 'B', 'B', 'B'],
+        'x': [1.0, 2.0, 3.0, 20.0, 22.0, 24.0]
+    })
+
+    t1 = TableOne(df, columns=['x'], groupby='group', pval=True, ttest_equal_var=False, pval_digits=5)
+    pval_welch = t1.tableone[('Grouped by group', 'P-Value')].iloc[1]
+    assert pval_welch == "0.00065"
+
+    t2 = TableOne(df, columns=['x'], groupby='group', pval=True, ttest_equal_var=True, pval_digits=5)
+    pval_welch = t2.tableone[('Grouped by group', 'P-Value')].iloc[1]
+    assert pval_welch == "0.00010"

--- a/tests/unit/test_tableone.py
+++ b/tests/unit/test_tableone.py
@@ -1428,5 +1428,5 @@ def test_ttest_equal_var_flag():
     assert pval_welch == "0.00065"
 
     t2 = TableOne(df, columns=['x'], groupby='group', pval=True, ttest_equal_var=True, pval_digits=5)
-    pval_welch = t2.tableone[('Grouped by group', 'P-Value')].iloc[1]
-    assert pval_welch == "0.00010"
+    pval = t2.tableone[('Grouped by group', 'P-Value')].iloc[1]
+    assert pval == "0.00010"


### PR DESCRIPTION
This pull request introduces a new `ttest_equal_var` argument to the TableOne class, allowing users to specify whether equal variances should be assumed when performing t-tests (see: https://github.com/tompollard/tableone/issues/193).

By default `ttest_equal_var=False`, which performs Welch’s t-test, a test that does not assume equal variance between groups.

```
df = pd.DataFrame({
    'group': ['A', 'A', 'A', 'B', 'B', 'B'],
    'x': [1.0, 2.0, 3.0, 20.0, 22.0, 24.0]
})
```

### `ttest_equal_var=False`

```
t1 = TableOne(df, columns=['x'], groupby='group', pval=True, ttest_equal_var=False, pval_digits=5)
pval_welch = t1.tableone[('Grouped by group', 'P-Value')].iloc[1]

# pval_welch == "0.00065"
```

### `ttest_equal_var=True`

```
t2 = TableOne(df, columns=['x'], groupby='group', pval=True, ttest_equal_var=True, pval_digits=5)
pval = t2.tableone[('Grouped by group', 'P-Value')].iloc[1]

# pval == "0.00010"
```



