### PR TITLE
Add `show_histograms` argument to display histograms (and `clip_histograms` for clipping outliers).

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tableone.ipynb
+++ b/tableone.ipynb
@@ -335,7 +335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -347,12 +347,12 @@
     "# Test for normality, multimodality (Hartigan's Dip Test), and far outliers (Tukey's test)\n",
     "\n",
     "# for versions >= 0.7.9\n",
-    "table1 = TableOne(data, dip_test=True, normal_test=True, tukey_test=True)"
+    "table1 = TableOne(data, dip_test=True, normal_test=True, tukey_test=True, show_histograms=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -388,6 +388,7 @@
        "      <th></th>\n",
        "      <th>Missing</th>\n",
        "      <th>Overall</th>\n",
+       "      <th>Histogram</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -396,79 +397,93 @@
        "      <th></th>\n",
        "      <td></td>\n",
        "      <td>1000</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Age, mean (SD)</th>\n",
        "      <th></th>\n",
        "      <td>0</td>\n",
        "      <td>65.0 (17.2)</td>\n",
+       "      <td>▂▂▃▄▆▇█▇</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>SysABP, mean (SD)</th>\n",
        "      <th></th>\n",
        "      <td>291</td>\n",
        "      <td>114.3 (40.2)</td>\n",
+       "      <td>▂▁▁▃█▆▃▁</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Height, mean (SD)</th>\n",
        "      <th></th>\n",
        "      <td>475</td>\n",
        "      <td>170.1 (22.1)</td>\n",
+       "      <td>▁▃▅▇▇█▂▁</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Weight, mean (SD)</th>\n",
        "      <th></th>\n",
        "      <td>302</td>\n",
        "      <td>82.9 (23.8)</td>\n",
+       "      <td>▃▆█▆▄▃▁▁</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"4\" valign=\"top\">ICU, n (%)</th>\n",
        "      <th>CCU</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>162 (16.2)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CSRU</th>\n",
        "      <td></td>\n",
        "      <td>202 (20.2)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>MICU</th>\n",
        "      <td></td>\n",
        "      <td>380 (38.0)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>SICU</th>\n",
        "      <td></td>\n",
        "      <td>256 (25.6)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"2\" valign=\"top\">MechVent, n (%)</th>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>540 (54.0)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td></td>\n",
        "      <td>460 (46.0)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>LOS, mean (SD)</th>\n",
        "      <th></th>\n",
        "      <td>0</td>\n",
        "      <td>14.2 (14.2)</td>\n",
+       "      <td>█▆▃▁▁▁▁▁</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"2\" valign=\"top\">death, n (%)</th>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>864 (86.4)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td></td>\n",
        "      <td>136 (13.6)</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -478,21 +493,21 @@
        "                                    in: Height, LOS.<br />"
       ],
       "text/plain": [
-       "                       Missing       Overall\n",
-       "n                                       1000\n",
-       "Age, mean (SD)               0   65.0 (17.2)\n",
-       "SysABP, mean (SD)          291  114.3 (40.2)\n",
-       "Height, mean (SD)          475  170.1 (22.1)\n",
-       "Weight, mean (SD)          302   82.9 (23.8)\n",
-       "ICU, n (%)        CCU        0    162 (16.2)\n",
-       "                  CSRU            202 (20.2)\n",
-       "                  MICU            380 (38.0)\n",
-       "                  SICU            256 (25.6)\n",
-       "MechVent, n (%)   0          0    540 (54.0)\n",
-       "                  1               460 (46.0)\n",
-       "LOS, mean (SD)               0   14.2 (14.2)\n",
-       "death, n (%)      0          0    864 (86.4)\n",
-       "                  1               136 (13.6)\n",
+       "                       Missing       Overall Histogram\n",
+       "n                                       1000          \n",
+       "Age, mean (SD)               0   65.0 (17.2)  ▂▂▃▄▆▇█▇\n",
+       "SysABP, mean (SD)          291  114.3 (40.2)  ▂▁▁▃█▆▃▁\n",
+       "Height, mean (SD)          475  170.1 (22.1)  ▁▃▅▇▇█▂▁\n",
+       "Weight, mean (SD)          302   82.9 (23.8)  ▃▆█▆▄▃▁▁\n",
+       "ICU, n (%)        CCU             162 (16.2)          \n",
+       "                  CSRU            202 (20.2)          \n",
+       "                  MICU            380 (38.0)          \n",
+       "                  SICU            256 (25.6)          \n",
+       "MechVent, n (%)   0               540 (54.0)          \n",
+       "                  1               460 (46.0)          \n",
+       "LOS, mean (SD)               0   14.2 (14.2)  █▆▃▁▁▁▁▁\n",
+       "death, n (%)      0               864 (86.4)          \n",
+       "                  1               136 (13.6)          \n",
        "[1] Hartigan's Dip Test reports possible\n",
        "                                    multimodal distributions for: Age, SysABP, Height, LOS.\n",
        "[2] Normality test reports non-normal\n",
@@ -501,7 +516,7 @@
        "                                    in: Height, LOS."
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -513,7 +528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -530,7 +545,7 @@
        "pandas.core.frame.DataFrame"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -570,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -587,7 +602,7 @@
        "(-30.0, 250.0)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -622,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -673,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -761,7 +776,7 @@
        "    <tr>\n",
        "      <th rowspan=\"4\" valign=\"top\">ICU, n (%)</th>\n",
        "      <th>CCU</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>162 (16.2)</td>\n",
        "      <td>137 (15.9)</td>\n",
        "      <td>25 (18.4)</td>\n",
@@ -802,7 +817,7 @@
        "SysABP, mean (SD)                            291        114.3 (40.2)        115.4 (38.3)         107.6 (49.4)\n",
        "Height, mean [min,max]                       475  170.1 [13.0,406.4]  170.3 [13.0,406.4]  168.5 [144.8,188.0]\n",
        "Weight, mean (SD)                            302         82.9 (23.8)         83.0 (23.6)          82.3 (25.4)\n",
-       "ICU, n (%)             CCU                     0          162 (16.2)          137 (15.9)            25 (18.4)\n",
+       "ICU, n (%)             CCU                                162 (16.2)          137 (15.9)            25 (18.4)\n",
        "                       CSRU                               202 (20.2)          194 (22.5)              8 (5.9)\n",
        "                       MICU                               380 (38.0)          318 (36.8)            62 (45.6)\n",
        "                       SICU                               256 (25.6)          215 (24.9)            41 (30.1)\n",
@@ -814,7 +829,7 @@
        "                                    in: Height, SysABP."
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -895,7 +910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -910,7 +925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -952,9 +967,9 @@
        "      <th>Overall</th>\n",
        "      <th>0</th>\n",
        "      <th>1</th>\n",
+       "      <th>SMD (0,1)</th>\n",
        "      <th>P-Value</th>\n",
        "      <th>Test</th>\n",
-       "      <th>SMD (0,1)</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -976,9 +991,9 @@
        "      <td>68.0 [53.0,79.0]</td>\n",
        "      <td>66.0 [52.8,78.0]</td>\n",
        "      <td>75.0 [62.0,83.0]</td>\n",
+       "      <td>0.487</td>\n",
        "      <td>&lt;0.001</td>\n",
        "      <td>Kruskal-Wallis</td>\n",
-       "      <td>0.487</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>SysABP, mean (SD)</th>\n",
@@ -987,9 +1002,9 @@
        "      <td>114.3 (40.2)</td>\n",
        "      <td>115.4 (38.3)</td>\n",
        "      <td>107.6 (49.4)</td>\n",
-       "      <td>0.134</td>\n",
-       "      <td>Two Sample T-test</td>\n",
        "      <td>-0.176</td>\n",
+       "      <td>0.134</td>\n",
+       "      <td>Welch’s T-test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Height, mean (SD)</th>\n",
@@ -998,9 +1013,9 @@
        "      <td>170.1 (22.1)</td>\n",
        "      <td>170.3 (23.2)</td>\n",
        "      <td>168.5 (11.3)</td>\n",
-       "      <td>0.304</td>\n",
-       "      <td>Two Sample T-test</td>\n",
        "      <td>-0.099</td>\n",
+       "      <td>0.304</td>\n",
+       "      <td>Welch’s T-test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Weight, mean (SD)</th>\n",
@@ -1009,20 +1024,20 @@
        "      <td>82.9 (23.8)</td>\n",
        "      <td>83.0 (23.6)</td>\n",
        "      <td>82.3 (25.4)</td>\n",
-       "      <td>0.782</td>\n",
-       "      <td>Two Sample T-test</td>\n",
        "      <td>-0.031</td>\n",
+       "      <td>0.782</td>\n",
+       "      <td>Welch’s T-test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"4\" valign=\"top\">ICU, n (%)</th>\n",
        "      <th>CCU</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>162 (16.2)</td>\n",
        "      <td>137 (15.9)</td>\n",
        "      <td>25 (18.4)</td>\n",
+       "      <td>0.490</td>\n",
        "      <td>&lt;0.001</td>\n",
        "      <td>Chi-squared</td>\n",
-       "      <td>0.490</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CSRU</th>\n",
@@ -1062,17 +1077,17 @@
        "                                    in: Height, SysABP.<br />"
       ],
       "text/plain": [
-       "                         Grouped by death                                                                                           \n",
-       "                                  Missing           Overall                 0                 1 P-Value               Test SMD (0,1)\n",
-       "n                                                      1000               864               136                                     \n",
-       "Age, median [Q1,Q3]                     0  68.0 [53.0,79.0]  66.0 [52.8,78.0]  75.0 [62.0,83.0]  <0.001     Kruskal-Wallis     0.487\n",
-       "SysABP, mean (SD)                     291      114.3 (40.2)      115.4 (38.3)      107.6 (49.4)   0.134  Two Sample T-test    -0.176\n",
-       "Height, mean (SD)                     475      170.1 (22.1)      170.3 (23.2)      168.5 (11.3)   0.304  Two Sample T-test    -0.099\n",
-       "Weight, mean (SD)                     302       82.9 (23.8)       83.0 (23.6)       82.3 (25.4)   0.782  Two Sample T-test    -0.031\n",
-       "ICU, n (%)          CCU                 0        162 (16.2)        137 (15.9)         25 (18.4)  <0.001        Chi-squared     0.490\n",
-       "                    CSRU                         202 (20.2)        194 (22.5)           8 (5.9)                                     \n",
-       "                    MICU                         380 (38.0)        318 (36.8)         62 (45.6)                                     \n",
-       "                    SICU                         256 (25.6)        215 (24.9)         41 (30.1)                                     \n",
+       "                         Grouped by death                                                                                        \n",
+       "                                  Missing           Overall                 0                 1 SMD (0,1) P-Value            Test\n",
+       "n                                                      1000               864               136                                  \n",
+       "Age, median [Q1,Q3]                     0  68.0 [53.0,79.0]  66.0 [52.8,78.0]  75.0 [62.0,83.0]     0.487  <0.001  Kruskal-Wallis\n",
+       "SysABP, mean (SD)                     291      114.3 (40.2)      115.4 (38.3)      107.6 (49.4)    -0.176   0.134  Welch’s T-test\n",
+       "Height, mean (SD)                     475      170.1 (22.1)      170.3 (23.2)      168.5 (11.3)    -0.099   0.304  Welch’s T-test\n",
+       "Weight, mean (SD)                     302       82.9 (23.8)       83.0 (23.6)       82.3 (25.4)    -0.031   0.782  Welch’s T-test\n",
+       "ICU, n (%)          CCU                          162 (16.2)        137 (15.9)         25 (18.4)     0.490  <0.001     Chi-squared\n",
+       "                    CSRU                         202 (20.2)        194 (22.5)           8 (5.9)                                  \n",
+       "                    MICU                         380 (38.0)        318 (36.8)         62 (45.6)                                  \n",
+       "                    SICU                         256 (25.6)        215 (24.9)         41 (30.1)                                  \n",
        "[1] Hartigan's Dip Test reports possible\n",
        "                                    multimodal distributions for: Age, Height, SysABP.\n",
        "[2] Normality test reports non-normal\n",
@@ -1081,7 +1096,7 @@
        "                                    in: Height, SysABP."
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1114,7 +1129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1124,7 +1139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1157,7 +1172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1176,7 +1191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1253,7 +1268,7 @@
        "      <td>170.3 (23.2)</td>\n",
        "      <td>168.5 (11.3)</td>\n",
        "      <td>0.304</td>\n",
-       "      <td>Two Sample T-test</td>\n",
+       "      <td>Welch’s T-test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Weight, mean (SD)</th>\n",
@@ -1263,12 +1278,12 @@
        "      <td>83.0 (23.6)</td>\n",
        "      <td>82.3 (25.4)</td>\n",
        "      <td>0.782</td>\n",
-       "      <td>Two Sample T-test</td>\n",
+       "      <td>Welch’s T-test</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th rowspan=\"4\" valign=\"top\">ICU, n (%)</th>\n",
        "      <th>CCU</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>162 (16.2)</td>\n",
        "      <td>137 (15.9)</td>\n",
        "      <td>25 (18.4)</td>\n",
@@ -1305,7 +1320,7 @@
        "    <tr>\n",
        "      <th rowspan=\"2\" valign=\"top\">MechVent, n (%)</th>\n",
        "      <th>0</th>\n",
-       "      <td>0</td>\n",
+       "      <td></td>\n",
        "      <td>540 (54.0)</td>\n",
        "      <td>468 (54.2)</td>\n",
        "      <td>72 (52.9)</td>\n",
@@ -1329,30 +1344,30 @@
        "      <td>14.0 (13.5)</td>\n",
        "      <td>15.4 (17.7)</td>\n",
        "      <td>0.386</td>\n",
-       "      <td>Two Sample T-test</td>\n",
+       "      <td>Welch’s T-test</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div><br />"
       ],
       "text/plain": [
-       "                       Grouped by death                                                                     \n",
-       "                                Missing       Overall             0             1 P-Value               Test\n",
-       "n                                                1000           864           136                           \n",
-       "Age, mean (SD)                        0   65.0 (17.2)   64.0 (17.4)   71.7 (14.0)  <0.001      Custom test 1\n",
-       "SysABP, mean (SD)                   291  114.3 (40.2)  115.4 (38.3)  107.6 (49.4)   0.012      Custom test 2\n",
-       "Height, mean (SD)                   475  170.1 (22.1)  170.3 (23.2)  168.5 (11.3)   0.304  Two Sample T-test\n",
-       "Weight, mean (SD)                   302   82.9 (23.8)   83.0 (23.6)   82.3 (25.4)   0.782  Two Sample T-test\n",
-       "ICU, n (%)        CCU                 0    162 (16.2)    137 (15.9)     25 (18.4)  <0.001        Chi-squared\n",
-       "                  CSRU                     202 (20.2)    194 (22.5)       8 (5.9)                           \n",
-       "                  MICU                     380 (38.0)    318 (36.8)     62 (45.6)                           \n",
-       "                  SICU                     256 (25.6)    215 (24.9)     41 (30.1)                           \n",
-       "MechVent, n (%)   0                   0    540 (54.0)    468 (54.2)     72 (52.9)   0.862        Chi-squared\n",
-       "                  1                        460 (46.0)    396 (45.8)     64 (47.1)                           \n",
-       "LOS, mean (SD)                        0   14.2 (14.2)   14.0 (13.5)   15.4 (17.7)   0.386  Two Sample T-test"
+       "                       Grouped by death                                                                  \n",
+       "                                Missing       Overall             0             1 P-Value            Test\n",
+       "n                                                1000           864           136                        \n",
+       "Age, mean (SD)                        0   65.0 (17.2)   64.0 (17.4)   71.7 (14.0)  <0.001   Custom test 1\n",
+       "SysABP, mean (SD)                   291  114.3 (40.2)  115.4 (38.3)  107.6 (49.4)   0.012   Custom test 2\n",
+       "Height, mean (SD)                   475  170.1 (22.1)  170.3 (23.2)  168.5 (11.3)   0.304  Welch’s T-test\n",
+       "Weight, mean (SD)                   302   82.9 (23.8)   83.0 (23.6)   82.3 (25.4)   0.782  Welch’s T-test\n",
+       "ICU, n (%)        CCU                      162 (16.2)    137 (15.9)     25 (18.4)  <0.001     Chi-squared\n",
+       "                  CSRU                     202 (20.2)    194 (22.5)       8 (5.9)                        \n",
+       "                  MICU                     380 (38.0)    318 (36.8)     62 (45.6)                        \n",
+       "                  SICU                     256 (25.6)    215 (24.9)     41 (30.1)                        \n",
+       "MechVent, n (%)   0                        540 (54.0)    468 (54.2)     72 (52.9)   0.862     Chi-squared\n",
+       "                  1                        460 (46.0)    396 (45.8)     64 (47.1)                        \n",
+       "LOS, mean (SD)                        0   14.2 (14.2)   14.0 (13.5)   15.4 (17.7)   0.386  Welch’s T-test"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1392,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1402,7 +1417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1412,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
@@ -1430,11 +1445,11 @@
       " SysABP, mean (SD) &      & 291       & 114.3 (40.2) & 115.4 (38.3) & 107.6 (49.4) \\\\\n",
       " Height, mean (SD) &      & 475       & 170.1 (22.1) & 170.3 (23.2) & 168.5 (11.3) \\\\\n",
       " Weight, mean (SD) &      & 302       & 82.9 (23.8)  & 83.0 (23.6)  & 82.3 (25.4)  \\\\\n",
-      " ICU, n (\\%)        & CCU  & 0         & 162 (16.2)   & 137 (15.9)   & 25 (18.4)    \\\\\n",
+      " ICU, n (\\%)        & CCU  &           & 162 (16.2)   & 137 (15.9)   & 25 (18.4)    \\\\\n",
       "                   & CSRU &           & 202 (20.2)   & 194 (22.5)   & 8 (5.9)      \\\\\n",
       "                   & MICU &           & 380 (38.0)   & 318 (36.8)   & 62 (45.6)    \\\\\n",
       "                   & SICU &           & 256 (25.6)   & 215 (24.9)   & 41 (30.1)    \\\\\n",
-      " MechVent, n (\\%)   & 0    & 0         & 540 (54.0)   & 468 (54.2)   & 72 (52.9)    \\\\\n",
+      " MechVent, n (\\%)   & 0    &           & 540 (54.0)   & 468 (54.2)   & 72 (52.9)    \\\\\n",
       "                   & 1    &           & 460 (46.0)   & 396 (45.8)   & 64 (47.1)    \\\\\n",
       " LOS, mean (SD)    &      & 0         & 14.2 (14.2)  & 14.0 (13.5)  & 15.4 (17.7)  \\\\\n",
       "\\hline\n",
@@ -1448,7 +1463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1462,11 +1477,11 @@
       "| SysABP, mean (SD) |      | 291       | 114.3 (40.2) | 115.4 (38.3) | 107.6 (49.4) |\n",
       "| Height, mean (SD) |      | 475       | 170.1 (22.1) | 170.3 (23.2) | 168.5 (11.3) |\n",
       "| Weight, mean (SD) |      | 302       | 82.9 (23.8)  | 83.0 (23.6)  | 82.3 (25.4)  |\n",
-      "| ICU, n (%)        | CCU  | 0         | 162 (16.2)   | 137 (15.9)   | 25 (18.4)    |\n",
+      "| ICU, n (%)        | CCU  |           | 162 (16.2)   | 137 (15.9)   | 25 (18.4)    |\n",
       "|                   | CSRU |           | 202 (20.2)   | 194 (22.5)   | 8 (5.9)      |\n",
       "|                   | MICU |           | 380 (38.0)   | 318 (36.8)   | 62 (45.6)    |\n",
       "|                   | SICU |           | 256 (25.6)   | 215 (24.9)   | 41 (30.1)    |\n",
-      "| MechVent, n (%)   | 0    | 0         | 540 (54.0)   | 468 (54.2)   | 72 (52.9)    |\n",
+      "| MechVent, n (%)   | 0    |           | 540 (54.0)   | 468 (54.2)   | 72 (52.9)    |\n",
       "|                   | 1    |           | 460 (46.0)   | 396 (45.8)   | 64 (47.1)    |\n",
       "| LOS, mean (SD)    |      | 0         | 14.2 (14.2)  | 14.0 (13.5)  | 15.4 (17.7)  |\n"
      ]
@@ -1487,7 +1502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1526,7 +1541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.19"
+   "version": "3.9.21"
   }
  },
  "nbformat": 4,

--- a/tableone/formatting.py
+++ b/tableone/formatting.py
@@ -291,3 +291,21 @@ def reorder_columns(table, optional_columns, groupby, order, overall):
         table = table.reindex(cols, axis=1)
 
     return table
+
+
+def generate_histograms(values, bins=8) -> str:
+    """
+    Generate a small Unicode histogram for an array of values.
+    """
+    breakpoint()
+    if len(values) == 0:
+        return ''
+    counts, _ = np.histogram(values, bins=bins)
+    max_count = counts.max()
+    if max_count == 0:
+        normalized = [0] * len(counts)
+    else:
+        normalized = (counts / max_count * 7).round().astype(int)
+
+    blocks = '▁▂▃▄▅▆▇█'
+    return ''.join(blocks[n] for n in normalized)

--- a/tableone/formatting.py
+++ b/tableone/formatting.py
@@ -293,19 +293,38 @@ def reorder_columns(table, optional_columns, groupby, order, overall):
     return table
 
 
-def generate_histograms(values, bins=8) -> str:
+def generate_histograms(values, bins=8, clip=(1, 99)):
     """
-    Generate a small Unicode histogram for an array of values.
+    Generate a mini histogram using unicode blocks.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Numeric values.
+    bins : int
+        Number of bins for the histogram.
+    clip : tuple of (int, int) or None, optional
+        If specified, clip values to the given (lower_percentile, upper_percentile).
+        For example, clip=(1, 99) clips to 1st and 99th percentiles.
+        If None, no clipping is applied.
+
+    Returns
+    -------
+    str
+        Unicode sparkline.
     """
-    breakpoint()
     if len(values) == 0:
         return ''
-    counts, _ = np.histogram(values, bins=bins)
-    max_count = counts.max()
-    if max_count == 0:
-        normalized = [0] * len(counts)
-    else:
-        normalized = (counts / max_count * 7).round().astype(int)
+
+    if clip is not None:
+        lower, upper = np.percentile(values, clip)
+        values = np.clip(values, lower, upper)
+
+    hist, _ = np.histogram(values, bins=bins)
+    if hist.max() == 0:
+        return ''
 
     blocks = '▁▂▃▄▅▆▇█'
-    return ''.join(blocks[n] for n in normalized)
+    hist_normalized = np.floor((hist / hist.max()) * (len(blocks) - 1)).astype(int)
+
+    return ''.join(blocks[i] for i in hist_normalized)

--- a/tests/test_histograms.py
+++ b/tests/test_histograms.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+
+from tableone import TableOne
+from tableone.formatting import generate_histograms
+
+
+def test_generate_histograms_simple():
+    # Simple case: clean data
+    x = np.linspace(0, 10, 100)
+    hist = generate_histograms(x)
+    assert isinstance(hist, str)
+    assert all(c in '▁▂▃▄▅▆▇█' for c in hist)
+
+
+def test_generate_histograms_empty_array():
+    # Edge case: empty array
+    x = np.array([])
+    hist = generate_histograms(x)
+    assert isinstance(hist, str)
+    assert hist == ''
+
+
+def test_clip_histogram_behavior():
+
+    # Create toy data: mostly normal values, plus strong outliers
+    rng = np.random.default_rng(seed=42)
+    normal_data = rng.normal(loc=50, scale=5, size=95)
+    outliers = np.array([300, 400, 500, 600, 1000])  # Big outliers
+    all_data = np.concatenate([normal_data, outliers])
+
+    df = pd.DataFrame({
+        'group': ['A'] * 50 + ['B'] * 50,
+        'value': all_data
+    })
+
+    # No clipping
+    t1_noclip = TableOne(df, columns=['value'], groupby='group', continuous=['value'],
+                         show_histograms=True, clip_histograms=None)
+
+    # With clipping
+    t1_clip = TableOne(df, columns=['value'], groupby='group', continuous=['value'],
+                       show_histograms=True, clip_histograms=(5, 95))
+
+    # Find the index for the summary row
+    main_row_idx = None
+    for idx in t1_noclip.tableone.index:
+        if idx[0].startswith('value') and idx[1] == '':
+            main_row_idx = idx
+            break
+
+    assert main_row_idx is not None, "Could not find main summary row for 'value'."
+
+    # Extract histograms
+    no_clip_hist = t1_noclip.tableone.loc[main_row_idx, ('Grouped by group', 'Overall Histogram')]
+    clip_hist = t1_clip.tableone.loc[main_row_idx, ('Grouped by group', 'Overall Histogram')]
+
+    # They should be different
+    assert no_clip_hist != clip_hist
+
+    # Histograms should not be empty
+    assert isinstance(no_clip_hist, str) and len(no_clip_hist) > 0
+    assert isinstance(clip_hist, str) and len(clip_hist) > 0
+
+
+def test_histogram_unicode_characters_only():
+    # Check that only expected unicode block characters are used
+    data = np.random.randn(100)
+    hist = generate_histograms(data)
+    block_chars = set('▁▂▃▄▅▆▇█')
+    assert set(hist).issubset(block_chars)


### PR DESCRIPTION
This pull request adds two new arguments to address #132:

```
    show_histograms : bool, default=False
        Whether to include mini-histograms for continuous variables.
    clip_histograms : tuple or None, default (1, 99)
        If show_histograms=True, specify a (lower_percentile, upper_percentile) range to clip the
        data before generating histograms. This reduces the influence of extreme outliers.
        For example, (1, 99) clips to the 1st and 99th percentiles.
        Set to None to disable clipping and use the full range of values.
```

When show_histograms is set to True, histograms will be added at the end of the table. A simple example is shown below:

```
from tableone import TableOne, load_dataset

data = load_dataset('pn2012')
table1 = TableOne(data, show_histograms=True)
print(table1.tabulate(tablefmt="rounded_outline"))

╭───────────────────┬──────┬───────────┬──────────────┬─────────────╮
│                   │      │ Missing   │ Overall      │ Histogram   │
├───────────────────┼──────┼───────────┼──────────────┼─────────────┤
│ n                 │      │           │ 1000         │             │
│ Age, mean (SD)    │      │ 0         │ 65.0 (17.2)  │ ▂▂▃▄▆▇█▇    │
│ SysABP, mean (SD) │      │ 291       │ 114.3 (40.2) │ ▂▁▁▃█▆▃▁    │
│ Height, mean (SD) │      │ 475       │ 170.1 (22.1) │ ▁▃▅▇▇█▂▁    │
│ Weight, mean (SD) │      │ 302       │ 82.9 (23.8)  │ ▃▆█▆▄▃▁▁    │
│ ICU, n (%)        │ CCU  │           │ 162 (16.2)   │             │
│                   │ CSRU │           │ 202 (20.2)   │             │
│                   │ MICU │           │ 380 (38.0)   │             │
│                   │ SICU │           │ 256 (25.6)   │             │
│ MechVent, n (%)   │ 0    │           │ 540 (54.0)   │             │
│                   │ 1    │           │ 460 (46.0)   │             │
│ LOS, mean (SD)    │      │ 0         │ 14.2 (14.2)  │ █▆▃▁▁▁▁▁    │
│ death, n (%)      │ 0    │           │ 864 (86.4)   │             │
│                   │ 1    │           │ 136 (13.6)   │             │
╰───────────────────┴──────┴───────────┴──────────────┴─────────────╯
```

An example of a stratified table is below:

```
╭───────────────────┬──────┬───────────┬──────────────┬──────────────┬───────────────┬───────────────┬─────────────────────╮
│                   │      │ Missing   │ 0            │ 1            │ 0 Histogram   │ 1 Histogram   │ Overall Histogram   │
├───────────────────┼──────┼───────────┼──────────────┼──────────────┼───────────────┼───────────────┼─────────────────────┤
│ n                 │      │           │ 864          │ 136          │               │               │                     │
│ Age, mean (SD)    │      │ 0         │ 64.0 (17.4)  │ 71.7 (14.0)  │ ▂▂▄▄▆▇█▇      │ ▁▂▃▄▄▆██      │ ▂▂▃▄▆▇█▇            │
│ SysABP, mean (SD) │      │ 291       │ 115.4 (38.3) │ 107.6 (49.4) │ ▂▁▁▂█▇▄▁      │ ▄▁▂▆██▄▂      │ ▂▁▁▃█▆▃▁            │
│ Height, mean (SD) │      │ 475       │ 170.3 (23.2) │ 168.5 (11.3) │ ▁▂▆▇▇█▂▁      │ ▂▆▄▅█▄▅▆      │ ▁▃▅▇▇█▂▁            │
│ Weight, mean (SD) │      │ 302       │ 83.0 (23.6)  │ 82.3 (25.4)  │ ▂▆█▆▄▂▁▁      │ ▅▇█▅▃▄▁▂      │ ▃▆█▆▄▃▁▁            │
│ ICU, n (%)        │ CCU  │           │ 137 (15.9)   │ 25 (18.4)    │               │               │                     │
│                   │ CSRU │           │ 194 (22.5)   │ 8 (5.9)      │               │               │                     │
│                   │ MICU │           │ 318 (36.8)   │ 62 (45.6)    │               │               │                     │
│                   │ SICU │           │ 215 (24.9)   │ 41 (30.1)    │               │               │                     │
╰───────────────────┴──────┴───────────┴──────────────┴──────────────┴───────────────┴───────────────┴─────────────────────╯
```