### PR TITLE
chore: add version ceilings to scientific Python dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
 ]
 dependencies = [
     "Jinja2 >= 3.1.4",
-    "numpy >= 1.19.1",
+    "numpy >= 1.19.1, <3",
     "openpyxl >= 3.1.2",
-    "pandas >= 2.0.3",
-    "scipy >= 1.10.1",
-    "statsmodels >= 0.14.1",
+    "pandas >= 2.0.3, <4",
+    "scipy >= 1.10.1, <2",
+    "statsmodels >= 0.14.1, <1",
     "tabulate >= 0.9.0",
 ]
 


### PR DESCRIPTION
## Summary

@tompollard Implements the proposal (closes #208) to add version ceilings to the scientific Python stack.

## Changes

```diff
- "numpy >= 1.19.1",
+ "numpy >= 1.19.1, <3",
- "pandas >= 2.0.3",
+ "pandas >= 2.0.3, <4",
- "scipy >= 1.10.1",
+ "scipy >= 1.10.1, <2",
- "statsmodels >= 0.14.1",
+ "statsmodels >= 0.14.1, <1",
```

## Rationale

Per [semantic versioning](https://semver.org/), major version bumps can include breaking changes. The pandas 3.0 release (#207) demonstrated this with strict string dtype enforcement.

| Dependency | Ceiling | Reasoning |
|------------|---------|-----------|
| pandas | <4 | Just broke with 3.0 (string dtype enforcement). |
| numpy | <3 | numpy 2.0 had significant breaking changes. |
| scipy | <2 | Scientific APIs can change between major versions. |
| statsmodels | <1 | Statistical APIs can change; currently pre-1.0. |
| Jinja2 | none | Simple templating use, stable API. |
| openpyxl | none | Stable Excel API. |
| tabulate | none | Simple formatting, stable API. |

## Benefits

- [x] Protects users from unexpected breakage when dependencies release new major versions.
- [x] Gives maintainers time to test and adapt to breaking changes.
- [x] Makes the supported version contract explicit rather than implicit.

## Related

- Issue #208 (proposal)
- PR #209 (pandas 3.0 compatibility fix)